### PR TITLE
Improve quality of life of SolverModel::Error

### DIFF
--- a/src/solvers/mod.rs
+++ b/src/solvers/mod.rs
@@ -101,7 +101,7 @@ pub trait SolverModel {
     /// The type of the solution to the problem
     type Solution: Solution;
     /// The error that can occur while solving the problem
-    type Error: 'static + Debug + std::error::Error;
+    type Error: std::error::Error;
 
     /// Takes a model and adds a constraint to it
     fn with(mut self, constraint: Constraint) -> Self

--- a/src/solvers/mod.rs
+++ b/src/solvers/mod.rs
@@ -101,7 +101,7 @@ pub trait SolverModel {
     /// The type of the solution to the problem
     type Solution: Solution;
     /// The error that can occur while solving the problem
-    type Error: Debug;
+    type Error: 'static + Debug + std::error::Error;
 
     /// Takes a model and adds a constraint to it
     fn with(mut self, constraint: Constraint) -> Self


### PR DESCRIPTION
### Problem
To implement a function `Fn -> Result`, the user has to constrain `SolverModel::Error` struct to `'static + std::error::Error` (see example below), which is quite inconvenient and confusing at first (same problem if using [`anyhow`](https://docs.rs/anyhow)).

### Implementation
This PR simply adds those constraints to the `Error` type definition so that the user can dispense with that verbose constraint. There may be a reason why this wasn't like that, but I don't see it. If that's the case, please disregard and close this PR.

### Example
Before this PR:
```rust
use good_lp::{default_solver, Solver, variables, SolverModel, Solution, constraint};

fn solve_example<S>(solver: S) -> Result<(), Box<dyn std::error::Error>>
where
    S: Solver,
    // Here
    <<S as good_lp::Solver>::Model as good_lp::SolverModel>::Error: 'static + std::error::Error
{
    variables!{
        vars:
               a <= 1;
          2 <= b <= 4;
    };
    let solution = vars.maximise(10 * (a - b / 5) - b)
        .using(solver)
        .with(constraint!(a + 2 <= b))
        .with(constraint!(1 + a >= 4 - b))
        .solve()?;
    println!("a={}   b={}", solution.value(a), solution.value(b));
    Ok(())
}

fn main() {
    solve_example(default_solver);
}
```
After this PR:
```rust
fn solve_example<S: Solver>(solver: S) -> Result<(), Box<dyn std::error::Error>> {
    variables!{
        vars:
               a <= 1;
          2 <= b <= 4;
    };
    let solution = vars.maximise(10 * (a - b / 5) - b)
        .using(solver)
        .with(constraint!(a + 2 <= b))
        .with(constraint!(1 + a >= 4 - b))
        .solve()?;
    println!("a={}   b={}", solution.value(a), solution.value(b));
    Ok(())
}
```

By the way, there is a typo in the `use` "contraint" at the example in the README.