### PR TITLE
Update float_eq to 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ fnv = "1"
 
 [dev-dependencies]
 criterion = "0.3"
-float_eq = "0.7"
+float_eq = "1.0"
 
 [[bench]]
 name = "benchmark"


### PR DESCRIPTION
Ran `cargo outdated` on the package and found this opportunity to update a dependency.