### PR TITLE
add the option to disable singlethreaded-cbc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,11 @@ categories = ["mathematics", "algorithms", "science", "api-bindings", "data-stru
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["coin_cbc"]
+default = ["coin_cbc", "singlethread-cbc"]
+singlethread-cbc = ["coin_cbc?/singlethread-cbc"]
 
 [dependencies]
-coin_cbc = { version = "0.1", optional = true }
+coin_cbc = { version = "0.1", optional = true, default-features = false }
 minilp = { version = "0.2", optional = true }
 lpsolve = { version = "0.1", optional = true }
 highs = { version = "1.2", optional = true }


### PR DESCRIPTION
The dependency [coin_cbc](https://github.com/KardinalAI/coin_cbc) uses a default feature, `singlethread-cbc`, to introduce a global lock around the `solve` function of Cbc. They give the following reason:

> This is because by default, libcbc is not thread safe. If you have compiled your own libcbc with the CBC_THREAD_SAFE option, you can disable this behavior by disabling the singlethread-cbc feature on this crate.

Unfortunately, if one includes your library and enables the `coin_cbc` feature, the dependency is added with all default features, and there is no way (to the best of my knowledge) to disable such a feature again.

This pull request also adds a default feature, `singlethread-cbc`, to this library which enables `coin_cbc/singlethread-cbc` if it is also included. This way, users of your library can opt out of `singlethread-cbc` if they can guarantee that they compiled the project with the appropriate falgs.