### PR TITLE
deps: fix minimal fnv version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ lpsolve = { version = "0.1", optional = true }
 highs = { version = "1.5.0", optional = true }
 russcip = { version = "0.1.13", optional = true }
 lp-solvers = { version = "0.0.4", features = ["cplex"], optional = true }
-fnv = "1"
+fnv = "1.0.5"
 
 [dev-dependencies]
 criterion = "0.4"


### PR DESCRIPTION
The API used by good_lp wasn't introduced until fnv v1.0.5 so the dependency version needs to be bumped.

ref https://github.com/servo/rust-fnv/releases/tag/v1.0.5