### PR TITLE
add support for SCIP cardinality constraints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ coin_cbc = { version = "0.1", optional = true, default-features = false }
 minilp = { version = "0.2", optional = true }
 lpsolve = { version = "0.1", optional = true }
 highs = { version = "1.5.0", optional = true }
-russcip = { version = "0.2.4", optional = true }
+russcip = { version = "0.2.6", optional = true }
 lp-solvers = { version = "1.0.0", features = ["cplex"], optional = true }
 fnv = "1.0.5"
 

--- a/src/cardinality_constraint_solver_trait.rs
+++ b/src/cardinality_constraint_solver_trait.rs
@@ -1,4 +1,4 @@
-use crate::{Variable, constraint::ConstraintReference};
+use crate::{constraint::ConstraintReference, Variable};
 
 /// A trait for solvers that support cardinality constraints
 pub trait CardinalityConstraintSolver {

--- a/src/cardinality_constraint_solver_trait.rs
+++ b/src/cardinality_constraint_solver_trait.rs
@@ -1,0 +1,7 @@
+use crate::{Variable, constraint::ConstraintReference};
+
+/// A trait for solvers that support cardinality constraints
+pub trait CardinalityConstraintSolver {
+    /// Add cardinality constraint. Constrains the number of non-zero variables from `vars` to at most `rhs`.
+    fn add_cardinality_constraint(&mut self, vars: &[Variable], rhs: usize) -> ConstraintReference;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,7 @@
 //!
 
 pub use affine_expression_trait::IntoAffineExpression;
+pub use cardinality_constraint_solver_trait::CardinalityConstraintSolver;
 pub use constraint::Constraint;
 pub use expression::Expression;
 #[cfg_attr(docsrs, doc(cfg(feature = "minilp")))]
@@ -149,6 +150,7 @@ mod expression;
 #[macro_use]
 pub mod variable;
 mod affine_expression_trait;
+mod cardinality_constraint_solver_trait;
 pub mod constraint;
 pub mod solvers;
 mod variables_macro;

--- a/src/solvers/scip.rs
+++ b/src/solvers/scip.rs
@@ -15,9 +15,9 @@ use russcip::WithSolutions;
 
 use crate::variable::{UnsolvedProblem, VariableDefinition};
 use crate::{
-    CardinalityConstraintSolver,
     constraint::ConstraintReference,
     solvers::{ObjectiveDirection, ResolutionError, Solution, SolverModel},
+    CardinalityConstraintSolver,
 };
 use crate::{Constraint, Variable};
 
@@ -87,16 +87,14 @@ impl SCIPProblem {
 impl CardinalityConstraintSolver for SCIPProblem {
     /// Add cardinality constraint. Constrains the number of non-zero variables to at most `rhs`.
     fn add_cardinality_constraint(&mut self, vars: &[Variable], rhs: usize) -> ConstraintReference {
-        let scip_vars = vars.iter()
+        let scip_vars = vars
+            .iter()
             .map(|v| Rc::clone(&self.id_for_var[v]))
             .collect::<Vec<_>>();
 
         let index = self.model.n_conss() + 1;
-        self.model.add_cons_cardinality(
-            scip_vars,
-            rhs,
-            format!("cardinality{}", index).as_str(),
-        );
+        self.model
+            .add_cons_cardinality(scip_vars, rhs, format!("cardinality{}", index).as_str());
 
         ConstraintReference { index }
     }
@@ -181,7 +179,9 @@ impl Solution for SCIPSolved {
 
 #[cfg(test)]
 mod tests {
-    use crate::{constraint, variable, variables, Solution, SolverModel, CardinalityConstraintSolver};
+    use crate::{
+        constraint, variable, variables, CardinalityConstraintSolver, Solution, SolverModel,
+    };
 
     use super::scip;
 
@@ -219,14 +219,9 @@ mod tests {
         let mut vars = variables!();
         let x = vars.add(variable().clamp(0, 2).integer());
         let y = vars.add(variable().clamp(0, 3).integer());
-        let mut model = vars
-            .maximise(5.0 * x + 3.0 * y)
-            .using(scip);
+        let mut model = vars.maximise(5.0 * x + 3.0 * y).using(scip);
         model.add_cardinality_constraint(&[x, y], 1);
-        let solution = model
-            .solve()
-            .unwrap();
+        let solution = model.solve().unwrap();
         assert_eq!((solution.value(x), solution.value(y)), (2., 0.));
     }
-
 }

--- a/src/solvers/scip.rs
+++ b/src/solvers/scip.rs
@@ -83,7 +83,7 @@ impl SCIPProblem {
     }
 
     /// Add cardinality constraint. Constrains the number of non-zero variables to at most `rhs`.
-    pub fn add_cardinality_constraint(&mut self, vars: &[Variable], rhs: i32) -> ConstraintReference {
+    pub fn add_cardinality_constraint(&mut self, vars: &[Variable], rhs: usize) -> ConstraintReference {
         let scip_vars = vars.iter()
             .map(|v| Rc::clone(&self.id_for_var[v]))
             .collect::<Vec<_>>();

--- a/src/solvers/scip.rs
+++ b/src/solvers/scip.rs
@@ -15,6 +15,7 @@ use russcip::WithSolutions;
 
 use crate::variable::{UnsolvedProblem, VariableDefinition};
 use crate::{
+    CardinalityConstraintSolver,
     constraint::ConstraintReference,
     solvers::{ObjectiveDirection, ResolutionError, Solution, SolverModel},
 };
@@ -81,9 +82,11 @@ impl SCIPProblem {
     pub fn as_inner_mut(&mut self) -> &mut Model<ProblemCreated> {
         &mut self.model
     }
+}
 
+impl CardinalityConstraintSolver for SCIPProblem {
     /// Add cardinality constraint. Constrains the number of non-zero variables to at most `rhs`.
-    pub fn add_cardinality_constraint(&mut self, vars: &[Variable], rhs: usize) -> ConstraintReference {
+    fn add_cardinality_constraint(&mut self, vars: &[Variable], rhs: usize) -> ConstraintReference {
         let scip_vars = vars.iter()
             .map(|v| Rc::clone(&self.id_for_var[v]))
             .collect::<Vec<_>>();
@@ -97,7 +100,6 @@ impl SCIPProblem {
 
         ConstraintReference { index }
     }
-
 }
 
 impl SolverModel for SCIPProblem {
@@ -179,7 +181,7 @@ impl Solution for SCIPSolved {
 
 #[cfg(test)]
 mod tests {
-    use crate::{constraint, variable, variables, Solution, SolverModel};
+    use crate::{constraint, variable, variables, Solution, SolverModel, CardinalityConstraintSolver};
 
     use super::scip;
 


### PR DESCRIPTION
This adds the ability of users to add cardinality constraints when using a SCIP optimizer.

This will also require a Cargo.toml change to a dependency version of russcip with the cardinality support, which is tracked by https://github.com/scipopt/russcip/pull/106 -- so this is not yet ready to merge.

(cardinality constraints allow a user to limit the number of non-zero variables from a given set in the solution to be <= N.)