### PR TITLE
Update clarabel to v0.9.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ highs = { version = "1.5.0", optional = true }
 russcip = { version = "0.3.4", optional = true }
 lp-solvers = { version = "1.0.0", features = ["cplex"], optional = true }
 cplex-rs = { version = "0.1", optional = true }
-clarabel = { version = "0.7.1", optional = true, features=[] }
+clarabel = { version = "0.9.0", optional = true, features = [] }
 fnv = "1.0.5"
 
 [dev-dependencies]


### PR DESCRIPTION
This updates clarabel to [v0.9.0](https://github.com/oxfordcontrol/Clarabel.rs/releases/tag/v0.9.0) which crucially includes a fix that makes it work on WASM.