### PR TITLE
build: add support for precompiled scip

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,8 @@ categories = ["mathematics", "algorithms", "science", "api-bindings", "data-stru
 default = ["coin_cbc", "singlethread-cbc"]
 singlethread-cbc = ["coin_cbc?/singlethread-cbc"]
 scip = ["russcip"]
-all_default_solvers = ["coin_cbc", "microlp", "lpsolve", "highs", "russcip", "lp-solvers", "clarabel"] # cplex-rs is not included because it is incompatible with lpsolve
+scip_bundled = ["russcip/bundled"]
+all_default_solvers = ["coin_cbc", "microlp", "lpsolve", "highs", "russcip/bundled", "lp-solvers", "clarabel"] # cplex-rs is not included because it is incompatible with lpsolve
 clarabel-wasm = ["clarabel/wasm"]
 minilp = ["microlp"] # minilp is not maintained anymore, we use the microlp fork instead
 

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Additionally, the end user of your program will have to install the desired solv
 
 SCIP is currently one of the fastest open-source solvers for mixed integer programming (MIP) and mixed integer nonlinear programming (MINLP). It is also a framework for constraint integer programming and branch-cut-and-price. It allows for total control of the solution process and the access of detailed information down to the guts of the solver.
 
-`good_lp` uses SCIP through the its rust interface [russcip](https://github.com/mmghannam/russcip) which can ship a precompiled binary. The easist way to use SCIP with `good_lp` is therefore to enable the `scip_bundled` feature.
+`good_lp` uses SCIP through its rust interface [russcip](https://github.com/mmghannam/russcip) which can ship a precompiled binary. The easiest way to use SCIP with `good_lp` is therefore to enable the `scip_bundled` feature.
 
 You can also use a custom installation of SCIP by enabling the `scip` feature instead. A good way of installing SCIP is by downloading a precompiled package from [here](https://scipopt.org/index.php#download) or through conda by running
 ```

--- a/README.md
+++ b/README.md
@@ -167,13 +167,13 @@ Additionally, the end user of your program will have to install the desired solv
 
 [lps]: https://crates.io/crates/lp-solvers
 
-
-
 ### [SCIP][scip]
 
 SCIP is currently one of the fastest open-source solvers for mixed integer programming (MIP) and mixed integer nonlinear programming (MINLP). It is also a framework for constraint integer programming and branch-cut-and-price. It allows for total control of the solution process and the access of detailed information down to the guts of the solver.
 
-`good_lp` uses SCIP through the its rust interface [russcip](https://github.com/mmghannam/russcip). To use this feature you will need to install SCIP. The easiest way to do it is to install a precompiled package from [here](https://scipopt.org/index.php#download) or through conda by running
+`good_lp` uses SCIP through the its rust interface [russcip](https://github.com/mmghannam/russcip) which can ship a precompiled binary. The easist way to use SCIP with `good_lp` is therefore to enable the `scip_bundled` feature.
+
+You can also use a custom installation of SCIP by enabling the `scip` feature instead. A good way of installing SCIP is by downloading a precompiled package from [here](https://scipopt.org/index.php#download) or through conda by running
 ```
 conda install --channel conda-forge scip
 ```


### PR DESCRIPTION
As discussed in https://github.com/rust-or/good_lp/pull/70#issuecomment-2561984500

I have run the tests and this seems to work, but I have now worked with Rust's features enough to know if my changes lead to good DX. Please roast me if needed.