### PR TITLE
add with_all function to model

### DIFF
--- a/src/solvers/mod.rs
+++ b/src/solvers/mod.rs
@@ -201,7 +201,7 @@ pub trait SolverModel {
     ///              .with_all([constraint!(x >= 1), constraint!(x <= 10)])
     ///              .solve()
     ///              .expect("example model, trivial to solve"); //
-    /// assert_eq!(result.eval(&x), 10.);
+    /// assert!((result.eval(&x) - 10.).abs() <= f64::EPSILON);
     /// ```
     fn with_all(mut self, constraints: impl IntoIterator<Item = Constraint>) -> Self
     where

--- a/src/solvers/mod.rs
+++ b/src/solvers/mod.rs
@@ -189,6 +189,17 @@ pub trait SolverModel {
         self
     }
 
+    /// Takes a model and adds a list of constraints to it
+    fn with_all(mut self, constraints: impl Iterator<Item = Constraint>) -> Self
+    where
+        Self: Sized,
+    {
+        for constraint in constraints {
+            self.add_constraint(constraint);
+        }
+        self
+    }
+
     /// Find the solution for the problem being modeled
     fn solve(self) -> Result<Self::Solution, Self::Error>;
 

--- a/src/solvers/mod.rs
+++ b/src/solvers/mod.rs
@@ -190,7 +190,20 @@ pub trait SolverModel {
     }
 
     /// Takes a model and adds a list of constraints to it
-    fn with_all(mut self, constraints: impl Iterator<Item = Constraint>) -> Self
+    ///
+    /// # Examples
+    /// ```rust
+    /// use good_lp::*;
+    /// let mut vars = variables!();
+    /// let x = vars.add_variable(); // unbounded variable
+    /// let result = vars.maximise(x)
+    ///              .using(default_solver)
+    ///              .with_all([constraint!(x >= 1), constraint!(x <= 10)])
+    ///              .solve()
+    ///              .expect("example model, trivial to solve"); //
+    /// assert_eq!(result.eval(&x), 10.);
+    /// ```
+    fn with_all(mut self, constraints: impl IntoIterator<Item = Constraint>) -> Self
     where
         Self: Sized,
     {

--- a/src/solvers/mod.rs
+++ b/src/solvers/mod.rs
@@ -196,10 +196,10 @@ pub trait SolverModel {
     /// use good_lp::*;
     /// let mut vars = variables!();
     /// let x = vars.add_variable(); // unbounded variable
-    /// let epsilon = 1e-10;
+    /// let epsilon = 1e-7; // works if epsilon is no smaller than this
     /// let result = vars.maximise(x)
     ///              .using(default_solver)
-    ///              .with_all([constraint!(x >= 1), constraint!(x <= 10)])
+    ///              .with_all([constraint!(x >= 1.), constraint!(x <= 10.)])
     ///              .solve()
     ///              .expect("example model, trivial to solve"); //
     /// assert!((result.eval(&x) - 10.).abs() <= epsilon)

--- a/src/solvers/mod.rs
+++ b/src/solvers/mod.rs
@@ -196,12 +196,13 @@ pub trait SolverModel {
     /// use good_lp::*;
     /// let mut vars = variables!();
     /// let x = vars.add_variable(); // unbounded variable
+    /// let epsilon = 1e-10;
     /// let result = vars.maximise(x)
     ///              .using(default_solver)
     ///              .with_all([constraint!(x >= 1), constraint!(x <= 10)])
     ///              .solve()
     ///              .expect("example model, trivial to solve"); //
-    /// assert!((result.eval(&x) - 10.).abs() <= f64::EPSILON);
+    /// assert!((result.eval(&x) - 10.).abs() <= epsilon)
     /// ```
     fn with_all(mut self, constraints: impl IntoIterator<Item = Constraint>) -> Self
     where


### PR DESCRIPTION
Adds the `with_all` function to the model. It is a convenience function for code organization in the case where people organize their code to have functions that return a list of constraints so that they can be added to the model in the regular builder function style instead of having to add them via
```rust
for constaint in constraints {
    model = model.with(constraint)
}
```
which breaks the builder pattern flow. 
Did not know where to put a unit test for the function or even if one is necessary. As long as `add_constraint()` works it should work as well but if a correct place for one is suggested I don't mind adding one. 