### PR TITLE
chore: do not bundle scip on docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,9 @@ harness = false
 [package.metadata.docs.rs]
 # Display the documentation for all solvers on docs.rs
 all-features = false
+# Use almost the same as all_default_solvers. Similarly, cplex-rs is not
+# included because it is incompatible with lpsolve. Additionally,
+# russcip/bundled is not included because network access is blocked on docs.rs.
 features = ["coin_cbc", "microlp", "lpsolve", "highs", "russcip", "lp-solvers", "clarabel"]
 default-target = "x86_64-unknown-linux-gnu"
 targets = ["x86_64-unknown-linux-gnu"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ harness = false
 [package.metadata.docs.rs]
 # Display the documentation for all solvers on docs.rs
 all-features = false
-features = [ "all_default_solvers" ]
+features = ["coin_cbc", "microlp", "lpsolve", "highs", "russcip", "lp-solvers", "clarabel"]
 default-target = "x86_64-unknown-linux-gnu"
 targets = ["x86_64-unknown-linux-gnu"]
 rustdoc-args = ["--cfg", "docsrs"]


### PR DESCRIPTION
Changes the build on docs.rs to avoid network access. This was introduced in #72 because bundling scip simplifies the build setup in both CI and locally.

Fixes #77.