### PR TITLE
build: fix all default solver features

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,8 @@
       "extensions": [
         "ms-azuretools.vscode-docker",
         "ms-vscode-remote.remote-containers",
-        "rust-lang.rust-analyzer"
+        "rust-lang.rust-analyzer",
+        "tamasfe.even-better-toml"
       ]
     }
   },

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,8 @@ all_default_solvers = [
     "microlp",
     "lpsolve",
     "highs",
-    "russcip",
-    "russcip/bundled",
+    "scip",
+    "scip_bundled",
     "lp-solvers",
     "clarabel",
 ] # cplex-rs is not included because it is incompatible with lpsolve


### PR DESCRIPTION
Previous, the deps were specified directly. This prevented the LSPs and the SCIP tests from being included when all default solvers were enabled.