### PR TITLE
docs: clarify behaviour of conflicting initials

### DIFF
--- a/src/solvers/mod.rs
+++ b/src/solvers/mod.rs
@@ -227,7 +227,7 @@ pub trait SolverModel {
 /// A solver that can take an initial solution to a problem before solving it
 pub trait WithInitialSolution {
     /// Sets the initial solution to the problem.
-    /// 
+    ///
     /// Note that calling this may cause some solvers to discard any initial
     /// values set on the variables themselves. It is advisable to rely either
     /// on `with_initial_solution`, or to set initial values on the variables

--- a/src/solvers/mod.rs
+++ b/src/solvers/mod.rs
@@ -226,7 +226,12 @@ pub trait SolverModel {
 
 /// A solver that can take an initial solution to a problem before solving it
 pub trait WithInitialSolution {
-    /// Sets the initial solution to the problem
+    /// Sets the initial solution to the problem.
+    /// 
+    /// Note that calling this may cause some solvers to discard any initial
+    /// values set on the variables themselves. It is advisable to rely either
+    /// on `with_initial_solution`, or to set initial values on the variables
+    /// directly, but not both.
     fn with_initial_solution(self, solution: impl IntoIterator<Item = (Variable, f64)>) -> Self;
 }
 

--- a/src/variable.rs
+++ b/src/variable.rs
@@ -181,7 +181,7 @@ impl VariableDefinition {
 
     /// Set the initial value of the variable. This may help the solver to find
     /// a solution significantly faster.
-    /// 
+    ///
     /// Note that the given value may be disregarded by some solvers if
     /// `with_initial_solution` is called on the problem instance. It is
     /// advisable to rely either on `with_initial_solution`, or to set initial

--- a/src/variable.rs
+++ b/src/variable.rs
@@ -182,10 +182,10 @@ impl VariableDefinition {
     /// Set the initial value of the variable. This may help the solver to find
     /// a solution significantly faster.
     /// 
-    /// Note that the given value may be disregarded if `with_initial_solution`
-    /// is called on the problem instance. It is advisable to rely either on
-    /// `with_initial_solution`, or to set initial values on the variables
-    /// directly, but not both.
+    /// Note that the given value may be disregarded by some solvers if
+    /// `with_initial_solution` is called on the problem instance. It is
+    /// advisable to rely either on `with_initial_solution`, or to set initial
+    /// values on the variables directly, but not both.
     ///
     /// **Warning**: not all solvers support initial solutions.
     /// Refer to the documentation of the solver you are using.

--- a/src/variable.rs
+++ b/src/variable.rs
@@ -179,7 +179,13 @@ impl VariableDefinition {
         self
     }
 
-    /// Set the initial value of the variable. This may help the solver to find a solution significantly faster.
+    /// Set the initial value of the variable. This may help the solver to find
+    /// a solution significantly faster.
+    /// 
+    /// Note that the given value may be disregarded if `with_initial_solution`
+    /// is called on the problem instance. It is advisable to rely either on
+    /// `with_initial_solution`, or to set initial values on the variables
+    /// directly, but not both.
     ///
     /// **Warning**: not all solvers support initial solutions.
     /// Refer to the documentation of the solver you are using.


### PR DESCRIPTION
Mention that initial solutions may overwrite initial variable values.