### PR TITLE
feat: allow inspection of variable definitions

### DIFF
--- a/src/variable.rs
+++ b/src/variable.rs
@@ -117,11 +117,11 @@ impl FormatWithVars for Variable {
 /// Defines the properties of a variable, such as its lower and upper bounds.
 #[derive(Clone, PartialEq, Debug)]
 pub struct VariableDefinition {
-    pub(crate) min: f64,
-    pub(crate) max: f64,
-    pub(crate) initial: Option<f64>,
-    pub(crate) name: String,
-    pub(crate) is_integer: bool,
+    pub min: f64,
+    pub max: f64,
+    pub initial: Option<f64>,
+    pub name: String,
+    pub is_integer: bool,
 }
 
 impl VariableDefinition {


### PR DESCRIPTION
This makes the fields in variable definitions public. That solves two problems I have. 

## Cannot Inspect Variable Definitions

Before variable definitions are added to the problem variables, they're very simple containers. After creating many of them, I'd like to log detailed information about their definitions so that I know what I'm passing to the solver. 

Currently, all fields are hidden. There is no way to inspect them after building them. Thus I'm currently forced to roll my own copy of variable definitions which let me do these inspections. I then translate them to the good_lp variable definitions (which effectively is a no-op). This could be improved by making the fields public. 

## Cannot Mutate by Reference

Another issue is that if one has an `&Vec<VariableDefinition>` then it is currently impossible to add a name, bounds, an int constraint, or an initial value to any of the definitions because the builder pattern always requires ownership. We could clone a variable and then overwrite the old value, but it feels wrong to do several copies just to flip a boolean.

This PR allows for a different workaround. The field can now be set directly by mutating the definition, which is better.