### PR TITLE
Support early solver stop without solution in HiGHS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "good_lp"
-version = "1.14.0"
+version = "1.14.1"
 authors = ["Ophir LOJKINE <contact@ophir.dev>"]
 edition = "2018"
 repository = "https://github.com/rust-or/good_lp"
@@ -40,7 +40,7 @@ minilp = [
 coin_cbc = { version = "0.1", optional = true, default-features = false }
 microlp = { version = "0.2.11", optional = true }
 lpsolve = { version = "1.0.1", optional = true }
-highs = { version = "1.11.0", optional = true }
+highs = { version = "2.0.0", optional = true }
 russcip = { version = "0.8.2", optional = true }
 lp-solvers = { version = "1.0.0", features = ["cplex"], optional = true }
 cplex-rs = { version = "0.1", optional = true }


### PR DESCRIPTION
If you put a stopping option as `.set_option("mip_max_nodes", 10)`, the solver might stop without finding a feasible solution. This modification handles this case by checking that a feasible solution is available, returning `Err(ResolutionError::Other("NoSolutionFound"))` if not.

depends on https://github.com/rust-or/highs/pull/32