### PR TITLE
Updated rust-lpsolve crate to 1.0.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ minilp = [
 [dependencies]
 coin_cbc = { version = "0.1", optional = true, default-features = false }
 microlp = { version = "0.2.11", optional = true }
-lpsolve = { version = "0.1", optional = true }
+lpsolve = { version = "1.0.1", optional = true }
 highs = { version = "1.11.0", optional = true }
 russcip = { version = "0.8.2", optional = true }
 lp-solvers = { version = "1.0.0", features = ["cplex"], optional = true }

--- a/src/solvers/lpsolve.rs
+++ b/src/solvers/lpsolve.rs
@@ -48,15 +48,17 @@ pub fn lp_solve(to_solve: UnsolvedProblem) -> LpSolveProblem {
 
     let cols = to_c(variables.len());
     let mut model = Problem::new(0, cols).expect("Unable to create problem");
-    let (obj_coefs, obj_idx, _const) = expr_to_scatter_vec(objective);
-    assert!(model.scatter_objective_function(&obj_coefs, &obj_idx));
+    let (mut obj_coefs, mut obj_idx, _const) = expr_to_scatter_vec(objective);
+    model
+        .scatter_objective_function(obj_coefs.as_mut_slice(), obj_idx.as_mut_slice())
+        .unwrap();
     for (i, v) in variables.into_iter().enumerate() {
         let col = to_c(i + 1);
-        assert!(model.set_integer(col, v.is_integer));
+        model.set_integer(col, v.is_integer).unwrap();
         if v.min.is_finite() || v.max.is_finite() {
-            assert!(model.set_bounds(col, v.min, v.max));
+            model.set_bounds(col, v.min, v.max).unwrap();
         } else {
-            assert!(model.set_unbounded(col));
+            model.set_unbounded(col).unwrap();
         }
     }
     LpSolveProblem(model)
@@ -114,8 +116,10 @@ impl SolverModel for LpSolveProblem {
         } else {
             ConstraintType::Le
         };
-        let success = self.0.add_constraint(&coeffs, target, constraint_type);
-        assert!(success, "could not add constraint. memory error.");
+        let success = self
+            .0
+            .add_constraint(coeffs.as_mut_slice(), target, constraint_type);
+        assert!(success.is_ok(), "could not add constraint. memory error.");
         ConstraintReference { index }
     }
 
@@ -135,8 +139,13 @@ impl ModelWithSOS1 for LpSolveProblem {
             variables.push(var.index().try_into().expect("too many vars"));
         }
         let name = CString::new("sos").unwrap();
-        self.0
-            .add_sos_constraint(&name, SOSType::Type1, 1, &weights, &variables);
+        self.0.add_sos_constraint(
+            &name,
+            SOSType::Type1,
+            1,
+            weights.as_mut_slice(),
+            variables.as_mut_slice(),
+        );
     }
 }
 


### PR DESCRIPTION
I would like to propose updating the rust-lpsolve crate from 0.1 to 1.0.1. The new version contains the methods set_timeout() and get_timeout() for impl Problem, which will allow the implementation of the trait WithTimeLimit for struct LpSolveProblem. In rust-lpsolve 1.0.1, the methods scatter_objective_function(), add_constraint(), and add_sos_constraint() no longer accept Vec<f64> and Vec<i32> types as arguments and accept &mut [f64] and &mut[i32] types instead, so the as_mut_slice() method was used to solve this issue. Also, scatter_objective_function(), set_integer(), set_bounds(), set_unbounded(), and add_constraint() now return Result<(), LpSolveError> types, so the unwrap() and is_ok() methods were used instead of assert statements for error checking. 