### PR TITLE
feat: add getter methods on fields of `Constraint`

### DIFF
--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -29,6 +29,18 @@ impl Constraint {
         self.name = Some(name);
         self
     }
+
+    pub fn expression(&self) -> &Expression {
+        &self.expression
+    }
+
+    pub fn is_equality(&self) -> bool {
+        self.is_equality
+    }
+    
+    pub fn name(&self) -> Option<&str> {
+        self.name.as_deref()
+    }
 }
 
 impl FormatWithVars for Constraint {

--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -30,14 +30,17 @@ impl Constraint {
         self
     }
 
+    /// The expression that is constrained to be null or negative
     pub fn expression(&self) -> &Expression {
         &self.expression
     }
 
+    /// if is_equality, represents expression == 0, otherwise, expression <= 0
     pub fn is_equality(&self) -> bool {
         self.is_equality
     }
-    
+
+    /// get the constraint name, if it exists.
     pub fn name(&self) -> Option<&str> {
         self.name.as_deref()
     }


### PR DESCRIPTION
Added getter methods for `Constraint`:

* Added `expression()` to return a reference to the `expression` field.
* Added `is_equality()` to return the value of the `is_equality` field.
* Added `name()` to return an optional reference to the `name` field as a string slice.