### PR TITLE
Prevent panics on invalid problem states

### DIFF
--- a/src/solvers/clarabel.rs
+++ b/src/solvers/clarabel.rs
@@ -11,6 +11,7 @@ use crate::{
 };
 
 use clarabel::algebra::CscMatrix;
+use clarabel::solver::SolverError;
 use clarabel::solver::SupportedConeT::{self, *};
 use clarabel::solver::implementations::default::DefaultSettingsBuilder;
 use clarabel::solver::{DefaultSolution, SolverStatus};
@@ -75,15 +76,26 @@ impl ClarabelProblem {
         &mut self.settings
     }
 
-    /// Convert the problem into a clarabel solver
-    /// panics if the problem is not valid
+    /// Convert the problem into a clarabel solver.
+    /// Panics if the problem is not valid.
     pub fn into_solver(self) -> DefaultSolver<f64> {
-        let settings = self.settings.build().expect("Invalid clarabel settings");
+        self.try_into_solver()
+            .expect("Invalid clarabel problem. This is likely a bug in good_lp. Problems should always have coherent dimensions.")
+    }
+
+    /// Convert the problem into a clarabel solver.
+    pub fn try_into_solver(self) -> Result<DefaultSolver<f64>, ResolutionError> {
+        let settings = self
+            .settings
+            .build()
+            .map_err(|e| ResolutionError::Str(format!("Invalid clarabel settings: {e}")))?;
+
         let quadratic_objective = &CscMatrix::zeros((self.variables, self.variables));
         let objective = &self.objective;
         let constraints = &self.constraints_matrix_builder.build();
         let constraint_values = &self.constraint_values;
         let cones = &self.cones;
+
         DefaultSolver::new(
             quadratic_objective,
             objective,
@@ -91,7 +103,8 @@ impl ClarabelProblem {
             constraint_values,
             cones,
             settings,
-        ).expect("Invalid clarabel problem. This is likely a bug in good_lp. Problems should always have coherent dimensions.")
+        )
+        .map_err(|error| ResolutionError::Str(error.to_string()))
     }
 }
 
@@ -100,7 +113,7 @@ impl SolverModel for ClarabelProblem {
     type Error = ResolutionError;
 
     fn solve(self) -> Result<Self::Solution, Self::Error> {
-        let mut solver = self.into_solver();
+        let mut solver = self.try_into_solver()?;
         solver.solve();
         match solver.solution.status {
             SolverStatus::PrimalInfeasible | SolverStatus::AlmostPrimalInfeasible => {

--- a/src/solvers/highs.rs
+++ b/src/solvers/highs.rs
@@ -279,24 +279,12 @@ impl SolverModel for HighsProblem {
                 })
         });
 
-        let mut model = self.try_into_inner()?;
+        let mut model = self.try_into_inner();
 
         if verbose {
-            model
-                .try_set_option(&b"output_flag"[..], true)
-                .map_err(|_| {
-                    ResolutionError::Str("HiGHS error while setting option output_flag".into())
-                })?;
-            model
-                .try_set_option(&b"log_to_console"[..], true)
-                .map_err(|_| {
-                    ResolutionError::Str("HiGHS error while setting option log_to_console".into())
-                })?;
-            model
-                .try_set_option(&b"log_dev_level"[..], 2)
-                .map_err(|_| {
-                    ResolutionError::Str("HiGHS error while setting option log_dev_level".into())
-                })?;
+            model.set_option(&b"output_flag"[..], true);
+            model.set_option(&b"log_to_console"[..], true);
+            model.set_option(&b"log_dev_level"[..], 2);
         }
 
         for (k, v) in options {
@@ -312,14 +300,8 @@ impl SolverModel for HighsProblem {
             })?;
         }
 
-        if let Some(solution) = initial_solution.as_deref() {
-            model
-                .try_set_solution(Some(solution), None, None, None)
-                .map_err(|e| {
-                    ResolutionError::Str(format!(
-                        "HiGHS error while setting initial solution: {e:?}"
-                    ))
-                })?;
+        if initial_solution.is_some() {
+            model.set_solution(initial_solution.as_deref(), None, None, None);
         }
 
         let solved = model

--- a/src/solvers/highs.rs
+++ b/src/solvers/highs.rs
@@ -279,7 +279,7 @@ impl SolverModel for HighsProblem {
                 })
         });
 
-        let mut model = self.try_into_inner();
+        let mut model = self.try_into_inner()?;
 
         if verbose {
             model.set_option(&b"output_flag"[..], true);

--- a/src/solvers/highs.rs
+++ b/src/solvers/highs.rs
@@ -188,9 +188,16 @@ pub struct HighsProblem {
 }
 
 impl HighsProblem {
-    /// Get a highs model for this problem
+    /// Get a highs model for this problem. Panics if the problem is invalid.
     pub fn into_inner(self) -> highs::Model {
-        self.highs_problem.optimise(self.sense)
+        self.try_into_inner().expect("HiGHS error: invalid problem")
+    }
+
+    /// Build a highs model for this problem.
+    pub fn try_into_inner(self) -> Result<highs::Model, ResolutionError> {
+        self.highs_problem
+            .try_optimise(self.sense)
+            .map_err(|e| ResolutionError::Str(format!("HiGHS error while building model: {e:?}")))
     }
 
     /// Sets whether or not HiGHS should display verbose logging information to the console
@@ -272,26 +279,53 @@ impl SolverModel for HighsProblem {
                 })
         });
 
-        let mut model = self.into_inner();
+        let mut model = self.try_into_inner()?;
+
         if verbose {
-            model.set_option(&b"output_flag"[..], true);
-            model.set_option(&b"log_to_console"[..], true);
-            model.set_option(&b"log_dev_level"[..], 2);
+            model
+                .try_set_option(&b"output_flag"[..], true)
+                .map_err(|_| {
+                    ResolutionError::Str("HiGHS error while setting option output_flag".into())
+                })?;
+            model
+                .try_set_option(&b"log_to_console"[..], true)
+                .map_err(|_| {
+                    ResolutionError::Str("HiGHS error while setting option log_to_console".into())
+                })?;
+            model
+                .try_set_option(&b"log_dev_level"[..], 2)
+                .map_err(|_| {
+                    ResolutionError::Str("HiGHS error while setting option log_dev_level".into())
+                })?;
         }
+
         for (k, v) in options {
-            match v {
-                HighsOptionValue::String(v) => model.set_option(k, v.as_str()),
-                HighsOptionValue::Float(v) => model.set_option(k, v),
-                HighsOptionValue::Bool(v) => model.set_option(k, v),
-                HighsOptionValue::Int(v) => model.set_option(k, v),
-            }
+            let result = match v {
+                HighsOptionValue::String(v) => model.try_set_option(k.as_str(), v.as_str()),
+                HighsOptionValue::Float(v) => model.try_set_option(k.as_str(), v),
+                HighsOptionValue::Bool(v) => model.try_set_option(k.as_str(), v),
+                HighsOptionValue::Int(v) => model.try_set_option(k.as_str(), v),
+            };
+
+            result.map_err(|_| {
+                ResolutionError::Str(format!("HiGHS error while setting option {k}"))
+            })?;
         }
 
-        if initial_solution.is_some() {
-            model.set_solution(initial_solution.as_deref(), None, None, None);
+        if let Some(solution) = initial_solution.as_deref() {
+            model
+                .try_set_solution(Some(solution), None, None, None)
+                .map_err(|e| {
+                    ResolutionError::Str(format!(
+                        "HiGHS error while setting initial solution: {e:?}"
+                    ))
+                })?;
         }
 
-        let solved = model.solve();
+        let solved = model
+            .try_solve()
+            .map_err(|e| ResolutionError::Str(format!("HiGHS error while solving model: {e:?}")))?;
+
         let status = match solved.status() {
             HighsModelStatus::NotSet => return Err(ResolutionError::Other("NotSet")),
             HighsModelStatus::LoadError => return Err(ResolutionError::Other("LoadError")),

--- a/src/solvers/lpsolve.rs
+++ b/src/solvers/lpsolve.rs
@@ -92,12 +92,11 @@ impl SolverModel for LpSolveProblem {
                 let truncated = self
                     .0
                     .get_solution_variables(&mut solution)
-                    .expect("internal error: invalid solution array length");
-                assert_eq!(
-                    truncated.len(),
-                    solution.len(),
-                    "The solution doesn't have the expected number of variables"
-                );
+                    .ok_or(ResolutionError::Other(
+                        "Failed to read solution variables from lp_solve",
+                    ))
+                    .map(|truncated| truncated.to_vec());
+
                 Ok(LpSolveSolution {
                     problem: self.0,
                     solution,

--- a/src/solvers/scip.rs
+++ b/src/solvers/scip.rs
@@ -288,16 +288,7 @@ impl SolverModel for SCIPProblem {
     type Error = ResolutionError;
 
     fn solve(self) -> Result<Self::Solution, Self::Error> {
-        let solved_model =
-            match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| self.model.solve())) {
-                Ok(model) => model,
-                Err(_) => {
-                    return Err(ResolutionError::Str(
-                        "SCIP failed to solve the problem".into(),
-                    ));
-                }
-            };
-
+        let solved_model = self.model.solve();
         let status = solved_model.status();
         match status {
             russcip::Status::TimeLimit => Ok(SCIPSolved {

--- a/src/solvers/scip.rs
+++ b/src/solvers/scip.rs
@@ -288,7 +288,16 @@ impl SolverModel for SCIPProblem {
     type Error = ResolutionError;
 
     fn solve(self) -> Result<Self::Solution, Self::Error> {
-        let solved_model = self.model.solve();
+        let solved_model =
+            match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| self.model.solve())) {
+                Ok(model) => model,
+                Err(_) => {
+                    return Err(ResolutionError::Str(
+                        "SCIP failed to solve the problem".into(),
+                    ));
+                }
+            };
+
         let status = solved_model.status();
         match status {
             russcip::Status::TimeLimit => Ok(SCIPSolved {


### PR DESCRIPTION
## Summary

`SolverModel::solve` is documented to return `Result<_, ResolutionError>`, but several solver backends panic on recoverable failures because they call panicking APIs from the underlying solver crates.

This PR makes `solve()` fallible along those paths by routing through the non-panicking APIs where they exist, and by adding new `try_*` helpers on `good_lp` types where needed. Existing public methods that panic (`into_inner`, `into_solver`, …) are **unchanged** and now delegate to the new fallible helpers.

Fixes panics for consumers who call `.solve()` and expect `Err(ResolutionError::…)` instead of a thread abort.

## Motivation

When using the HiGHS backend, invalid models, bad solver options, or failed solves could panic inside `RowProblem::optimise`, `Model::solve`, or `Model::set_option` — even though `HighsProblem` implements `SolverModel::Error = ResolutionError`.

The same pattern appeared in other backends: Clarabel used `expect` when building the solver, lp_solve used `expect`/`assert_eq!` when reading the solution vector, and SCIP could panic when russcip’s `Model::solve` fails at the API level.

## API impact

**No breaking changes.** New methods:

- `HighsProblem::try_into_inner() -> Result<highs::Model, ResolutionError>`
- `ClarabelProblem::try_into_solver() -> Result<DefaultSolver<f64>, ResolutionError>`

Existing panicking APIs retain the same signatures and behavior.

## Notes

- Panics during **model construction** (e.g. Clarabel + integer variables) and in **`add_constraint`** paths are out of scope for this PR.
- SCIP uses `catch_unwind` as a last resort; a cleaner fix would be a `try_solve` in russcip.
- Per `CONTRIBUTING.md`: no README/doc-test updates required unless we want to document the new `try_*` helpers explicitly.