### PR TITLE
feat: Add Google OR-Tools CP-SAT solver

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: install deps
-        run: NO_CPLEX=true ./build/setup.sh
+        run: NO_CPLEX=true NO_CPSAT=true ./build/setup.sh
       - name: Build with all default solvers (no cplex)
         run: cargo build --features all_default_solvers --tests
       - name: Run tests with all default solvers (no cplex)
@@ -42,7 +42,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: install deps
-        run: NO_CPLEX=true ./build/setup.sh
+        run: NO_CPLEX=true NO_CPSAT=true ./build/setup.sh
       - name: Build microlp
         run: cargo build --features microlp --tests
       - name: Run tests with microlp
@@ -58,7 +58,7 @@ jobs:
         with:
           node-version: 24
       - name: install deps
-        run: NO_CPLEX=true ./build/setup.sh && ./build/postsetup.sh
+        run: NO_CPLEX=true NO_CPSAT=true ./build/setup.sh && ./build/postsetup.sh
       - name: Run tests with microlp on WASM
         run: wasm-pack test --node --no-default-features --features microlp
 
@@ -69,7 +69,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: install deps
-        run: NO_CPLEX=true ./build/setup.sh
+        run: NO_CPLEX=true NO_CPSAT=true ./build/setup.sh
       - name: Build microlp
         run: cargo build --features lpsolve --tests
       - name: Run tests with lpsolve
@@ -82,7 +82,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: install deps
-        run: NO_CPLEX=true ./build/setup.sh
+        run: NO_CPLEX=true NO_CPSAT=true ./build/setup.sh
       - name: Build highs
         run: cargo build --features highs --tests
       - name: Run tests with highs
@@ -95,7 +95,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: install deps
-        run: NO_CPLEX=true ./build/setup.sh
+        run: NO_CPLEX=true NO_CPSAT=true ./build/setup.sh
       - name: Build lp_solvers
         run: cargo build --features lp-solvers --tests
       - name: Run tests with lp_solvers
@@ -108,7 +108,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: install deps
-        run: NO_CPLEX=true ./build/setup.sh
+        run: NO_CPLEX=true NO_CPSAT=true ./build/setup.sh
       - name: Build scip
         run: cargo build --features "scip,scip_bundled" --tests
       - name: Run tests with SCIP
@@ -121,7 +121,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: install deps
-        run: ./build/setup.sh
+        run: NO_CPSAT=true ./build/setup.sh
       - name: Build cplex
         run: cargo build --features cplex-rs --tests
       - name: Run tests with CPLEX
@@ -134,7 +134,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: install deps
-        run: NO_CPLEX=true ./build/setup.sh
+        run: NO_CPLEX=true NO_CPSAT=true ./build/setup.sh
       - name: Build clarabel
         run: cargo build --features clarabel --tests
       - name: Run tests with Clarabel
@@ -150,9 +150,30 @@ jobs:
         with:
           node-version: 22
       - name: install deps
-        run: NO_CPLEX=true ./build/setup.sh && ./build/postsetup.sh
+        run: NO_CPLEX=true NO_CPSAT=true ./build/setup.sh && ./build/postsetup.sh
       - name: Run tests with Clarabel on WASM
         run: wasm-pack test --node --no-default-features --features clarabel
+
+  test-cp-sat:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: install deps
+        run: NO_CPLEX=true ./build/setup.sh
+      - name: Build cp_sat
+        run: cargo build --features cp_sat --tests
+        env:
+          ORTOOLS_PREFIX: /opt/ortools
+          RUSTFLAGS: -L /opt/ortools/lib -lprotobuf
+          LD_LIBRARY_PATH: /opt/ortools/lib
+      - name: Run tests with cp_sat
+        run: cargo test --no-default-features --features cp_sat --lib -- cp_sat
+        env:
+          ORTOOLS_PREFIX: /opt/ortools
+          RUSTFLAGS: -L /opt/ortools/lib -lprotobuf
+          LD_LIBRARY_PATH: /opt/ortools/lib
 
   bench:
     runs-on: ubuntu-latest
@@ -161,6 +182,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: install deps
-        run: NO_CPLEX=true ./build/setup.sh
+        run: NO_CPLEX=true NO_CPSAT=true ./build/setup.sh
       - name: Run benchmarks
         run: cargo bench

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -164,16 +164,8 @@ jobs:
         run: NO_CPLEX=true ./build/setup.sh
       - name: Build cp_sat
         run: cargo build --features cp_sat --tests
-        env:
-          ORTOOLS_PREFIX: /opt/ortools
-          RUSTFLAGS: -L /opt/ortools/lib -lprotobuf
-          LD_LIBRARY_PATH: /opt/ortools/lib
       - name: Run tests with cp_sat
         run: cargo test --no-default-features --features cp_sat --lib -- cp_sat
-        env:
-          ORTOOLS_PREFIX: /opt/ortools
-          RUSTFLAGS: -L /opt/ortools/lib -lprotobuf
-          LD_LIBRARY_PATH: /opt/ortools/lib
 
   bench:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,6 @@ minilp = [
     "microlp",
 ] # minilp is not maintained anymore, we use the microlp fork instead
 
-
 [dependencies]
 coin_cbc = { version = "0.1", optional = true, default-features = false }
 microlp = { version = "0.4.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ default = ["coin_cbc", "singlethread-cbc"]
 singlethread-cbc = ["coin_cbc?/singlethread-cbc"]
 scip = ["russcip"]
 scip_bundled = ["russcip?/bundled"]
+cp_sat = ["dep:cp_sat"]
 all_default_solvers = [
     "coin_cbc",
     "microlp",
@@ -36,6 +37,7 @@ minilp = [
     "microlp",
 ] # minilp is not maintained anymore, we use the microlp fork instead
 
+
 [dependencies]
 coin_cbc = { version = "0.1", optional = true, default-features = false }
 microlp = { version = "0.4.0", optional = true }
@@ -45,6 +47,7 @@ russcip = { version = "0.9.1", optional = true }
 lp-solvers = { version = "1.0.0", features = ["cplex"], optional = true }
 cplex-rs = { version = "0.1.9", optional = true }
 clarabel = { version = "0.11.0", optional = true, features = [] }
+cp_sat = { version = "0.4.0", optional = true }
 fnv = "1.0.5"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ russcip = { version = "0.9.1", optional = true }
 lp-solvers = { version = "1.0.0", features = ["cplex"], optional = true }
 cplex-rs = { version = "0.1.9", optional = true }
 clarabel = { version = "0.11.0", optional = true, features = [] }
-cp_sat = { version = "0.4.0", optional = true }
+cp_sat = { version = "0.4.1", optional = true }
 fnv = "1.0.5"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ default = ["coin_cbc", "singlethread-cbc"]
 singlethread-cbc = ["coin_cbc?/singlethread-cbc"]
 scip = ["russcip"]
 scip_bundled = ["russcip?/bundled"]
-cp_sat = ["dep:cp_sat"]
 all_default_solvers = [
     "coin_cbc",
     "microlp",

--- a/README.md
+++ b/README.md
@@ -69,17 +69,17 @@ You can find a resource allocation problem example in
 This library offers an abstraction over multiple solvers. By default, it uses [cbc][cbc], but
 you can also activate other solvers using cargo features.
 
-| solver feature name    | integer variables | no C compiler\* | no additional libs\*   | fast\* | WASM\* |
-| ---------------------- | ----------------- | --------------- | ---------------------- | ---- | ---- |
-| [`coin_cbc`][cbc]      | ✅                | ✅              | ❌                     | ✅   | ❌   |
-| [`highs`][highs]       | ✅                | ❌              | ✅¹                    | ✅   | ❌   |
-| [`lpsolve`][lpsolve]   | ✅                | ❌              | ✅                     | ❌   | ❌   |
-| [`microlp`][microlp]   | ✅                | ✅              | ✅                     | ❌   | ✅   |
-| [`lp-solvers`][lps]    | ✅                | ✅              | ✅                     | ❌   | ❌   |
-| [`scip`][scip]         | ✅                | ✅              | ✅²                    | ✅   | ❌   |
-| [`cplex-rs`][cplex]    | ✅                | ❌              | ✅³                    | ✅   | ❌   |
-| [`clarabel`][clarabel] | ❌                | ✅              | ✅                     | ✅   | ✅   |
-| [`cp_sat`][cp_sat]     | ✅                | ❌              | ❌                     | ✅   | ❌   |
+| solver feature name    | integer variables | continuous variables | no C compiler\* | no additional libs\*   | fast\* | WASM\* |
+| ---------------------- | ----------------- | -------------------- | --------------- | ---------------------- | ---- | ---- |
+| [`coin_cbc`][cbc]      | ✅                | ✅                   | ✅              | ❌                     | ✅   | ❌   |
+| [`highs`][highs]       | ✅                | ✅                   | ❌              | ✅¹                    | ✅   | ❌   |
+| [`lpsolve`][lpsolve]   | ✅                | ✅                   | ❌              | ✅                     | ❌   | ❌   |
+| [`microlp`][microlp]   | ✅                | ✅                   | ✅              | ✅                     | ❌   | ✅   |
+| [`lp-solvers`][lps]    | ✅                | ✅                   | ✅              | ✅                     | ❌   | ❌   |
+| [`scip`][scip]         | ✅                | ✅                   | ✅              | ✅²                    | ✅   | ❌   |
+| [`cplex-rs`][cplex]    | ✅                | ✅                   | ❌              | ✅³                    | ✅   | ❌   |
+| [`clarabel`][clarabel] | ❌                | ✅                   | ✅              | ✅                     | ✅   | ✅   |
+| [`cp_sat`][cp_sat]     | ✅                | ❌                   | ❌              | ❌                     | ✅   | ❌   |
 
 - \* *no C compiler*: builds with only cargo, without requiring you to install a C compiler
 - \* *no additional libs*: works without additional libraries at runtime, all the dependencies are statically linked
@@ -216,7 +216,7 @@ trait, which allows you to access the dual values of the constraints (the shadow
 [CP-SAT](https://developers.google.com/optimization/cp/cp_solver) is Google's fast constraint programming solver,
 part of [OR-Tools](https://developers.google.com/optimization). It is one of the fastest open-source solvers
 for combinatorial (integer) optimization problems, supporting both integer and boolean variables.
-CP-SAT does not support continuous (floating-point) variables; using a non-integer variable will cause a panic.
+CP-SAT does **not** support continuous (floating-point) variables; using a non-integer variable will cause a panic.
 
 good_lp uses the [cp_sat crate](https://crates.io/crates/cp_sat) to call the OR-Tools CP-SAT solver
 through its C++ API.

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ you can also activate other solvers using cargo features.
 | [`scip`][scip]         | ✅                | ✅              | ✅²                    | ✅   | ❌   |
 | [`cplex-rs`][cplex]    | ✅                | ❌              | ✅³                    | ✅   | ❌   |
 | [`clarabel`][clarabel] | ❌                | ✅              | ✅                     | ✅   | ✅   |
+| [`cp_sat`][cp_sat]     | ✅                | ❌              | ❌                     | ✅   | ❌   |
 
 - \* *no C compiler*: builds with only cargo, without requiring you to install a C compiler
 - \* *no additional libs*: works without additional libraries at runtime, all the dependencies are statically linked
@@ -209,6 +210,36 @@ It does implement the [SolutionWithDual](https://docs.rs/good_lp/latest/good_lp/
 trait, which allows you to access the dual values of the constraints (the shadow prices).
 
 [clarabel]: https://github.com/oxfordcontrol/Clarabel.rs
+
+### [CP-SAT][cp_sat]
+
+[CP-SAT](https://developers.google.com/optimization/cp/cp_solver) is Google's constraint programming solver,
+part of [OR-Tools](https://developers.google.com/optimization). It is one of the fastest open-source solvers
+for combinatorial (integer) optimization problems, supporting both integer and boolean variables.
+CP-SAT does not support continuous (floating-point) variables; using a non-integer variable will cause a panic.
+
+good_lp uses the [cp_sat crate](https://crates.io/crates/cp_sat) to call the OR-Tools CP-SAT solver
+through its C++ API.
+
+To use CP-SAT, you must install the OR-Tools shared library on your system.
+On Ubuntu 24.04, you can install it as follows:
+
+```bash
+curl -LO 'https://github.com/google/or-tools/releases/download/v9.15/or-tools_amd64_ubuntu-24.04_cpp_v9.15.6755.tar.gz'
+sudo mkdir -p /opt/ortools
+sudo tar -xzf or-tools_amd64_ubuntu-24.04_cpp_v9.15.6755.tar.gz -C /opt/ortools --strip-components=1
+cd /opt/ortools && sudo make test
+```
+
+Then set the following environment variables when building and running:
+
+```bash
+export ORTOOLS_PREFIX=/opt/ortools
+export RUSTFLAGS="-L /opt/ortools/lib -lprotobuf"
+export LD_LIBRARY_PATH=/opt/ortools/lib
+```
+
+[cp_sat]: https://developers.google.com/optimization/cp/cp_solver
 
 ## Variable types
 

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ trait, which allows you to access the dual values of the constraints (the shadow
 
 ### [CP-SAT][cp_sat]
 
-[CP-SAT](https://developers.google.com/optimization/cp/cp_solver) is Google's constraint programming solver,
+[CP-SAT](https://developers.google.com/optimization/cp/cp_solver) is Google's fast constraint programming solver,
 part of [OR-Tools](https://developers.google.com/optimization). It is one of the fastest open-source solvers
 for combinatorial (integer) optimization problems, supporting both integer and boolean variables.
 CP-SAT does not support continuous (floating-point) variables; using a non-integer variable will cause a panic.

--- a/README.md
+++ b/README.md
@@ -222,22 +222,9 @@ good_lp uses the [cp_sat crate](https://crates.io/crates/cp_sat) to call the OR-
 through its C++ API.
 
 To use CP-SAT, you must install the OR-Tools shared library on your system.
-On Ubuntu 24.04, you can install it as follows:
-
-```bash
-curl -LO 'https://github.com/google/or-tools/releases/download/v9.15/or-tools_amd64_ubuntu-24.04_cpp_v9.15.6755.tar.gz'
-sudo mkdir -p /opt/ortools
-sudo tar -xzf or-tools_amd64_ubuntu-24.04_cpp_v9.15.6755.tar.gz -C /opt/ortools --strip-components=1
-cd /opt/ortools && sudo make test
-```
-
-Then set the following environment variables when building and running:
-
-```bash
-export ORTOOLS_PREFIX=/opt/ortools
-export RUSTFLAGS="-L /opt/ortools/lib -lprotobuf"
-export LD_LIBRARY_PATH=/opt/ortools/lib
-```
+See the [OR-Tools installation guide](https://developers.google.com/optimization/install) for instructions.
+The cp_sat crate automatically discovers OR-Tools installed in standard locations (`/usr/local`, `/usr`,
+`/opt/ortools`, etc.) or via the `ORTOOLS_PREFIX` environment variable.
 
 [cp_sat]: https://developers.google.com/optimization/cp/cp_solver
 

--- a/README.md
+++ b/README.md
@@ -226,6 +226,8 @@ See the [OR-Tools installation guide](https://developers.google.com/optimization
 The cp_sat crate automatically discovers OR-Tools installed in standard locations (`/usr/local`, `/usr`,
 `/opt/ortools`, etc.) or via the `ORTOOLS_PREFIX` environment variable.
 
+If you get a runtime error like `error while loading shared libraries: libortools.so.9`, add your OR-Tools library directory to `LD_LIBRARY_PATH`, or configure the runtime linker via `ldconfig`. The `cp_sat` crate's build script embeds the OR-Tools library path into the binary, but due to a [cargo limitation](https://github.com/rust-lang/cargo/issues/12843) this does not propagate to downstream projects, causing problems on systems where the installation location is not in the default search path.
+
 [cp_sat]: https://developers.google.com/optimization/cp/cp_solver
 
 ## Variable types

--- a/build/setup.sh
+++ b/build/setup.sh
@@ -16,3 +16,13 @@ then
     chmod u+x cplex.bin
     ./cplex.bin -f ./response.properties
 fi
+
+# Install OR-Tools for CP-SAT
+if [ -z "$NO_CPSAT" ]
+then
+    cd /tmp
+    curl -LO 'https://github.com/google/or-tools/releases/download/v9.15/or-tools_amd64_ubuntu-24.04_cpp_v9.15.6755.tar.gz'
+    sudo mkdir -p /opt/ortools
+    sudo tar -xzf or-tools_amd64_ubuntu-24.04_cpp_v9.15.6755.tar.gz -C /opt/ortools --strip-components=1
+    cd /opt/ortools && sudo make test
+fi

--- a/build/setup.sh
+++ b/build/setup.sh
@@ -22,7 +22,7 @@ if [ -z "$NO_CPSAT" ]
 then
     cd /tmp
     curl -LO 'https://github.com/google/or-tools/releases/download/v9.15/or-tools_amd64_ubuntu-24.04_cpp_v9.15.6755.tar.gz'
-    sudo mkdir -p /opt/ortools
-    sudo tar -xzf or-tools_amd64_ubuntu-24.04_cpp_v9.15.6755.tar.gz -C /opt/ortools --strip-components=1
-    cd /opt/ortools && sudo make test
+    sudo tar -xzf or-tools_amd64_ubuntu-24.04_cpp_v9.15.6755.tar.gz \
+        -C /usr/local --strip-components=1
+    sudo ldconfig
 fi

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,19 +3,6 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 //!  A Linear Programming modeler that is easy to use, performant with large problems, and well-typed.
 //!
-//! # Solvers
-//!
-//! The following solvers are available:
-//!
-//! - [`coin_cbc`](solvers::coin_cbc) - [COIN-OR CBC](https://www.coin-or.org/Cbc/) (enabled by default)
-//! - [`cp_sat`](solvers::cp_sat) - [Google OR-Tools CP-SAT](https://developers.google.com/optimization/cp/cp_solver) (requires `cp_sat` feature)
-//! - [`microlp`](solvers::microlp) - A lightweight LP solver
-//! - [`lpsolve`](solvers::lpsolve) - [LpSolve](http://lpsolve.sourceforge.net/)
-//! - [`highs`](solvers::highs) - [HiGHS](https://highs.dev/)
-//! - [`scip`](solvers::scip) - [SCIP](https://scipopt.org/)
-//! - [`lp-solvers`](solvers::lp_solvers) - A wrapper around several LP solvers
-//! - [`clarabel`](solvers::clarabel) - [Clarabel](https://github.com/oxfordcontrol/Clarabel.rs)
-//!
 //!  ```rust
 //!  use good_lp::{variables, variable, default_solver, SolverModel, Solution};
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,19 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 //!  A Linear Programming modeler that is easy to use, performant with large problems, and well-typed.
 //!
+//! # Solvers
+//!
+//! The following solvers are available:
+//!
+//! - [`coin_cbc`](solvers::coin_cbc) - [COIN-OR CBC](https://www.coin-or.org/Cbc/) (enabled by default)
+//! - [`cp_sat`](solvers::cp_sat) - [Google OR-Tools CP-SAT](https://developers.google.com/optimization/cp/cp_solver) (requires `cp_sat` feature)
+//! - [`microlp`](solvers::microlp) - A lightweight LP solver
+//! - [`lpsolve`](solvers::lpsolve) - [LpSolve](http://lpsolve.sourceforge.net/)
+//! - [`highs`](solvers::highs) - [HiGHS](https://highs.dev/)
+//! - [`scip`](solvers::scip) - [SCIP](https://scipopt.org/)
+//! - [`lp-solvers`](solvers::lp_solvers) - A wrapper around several LP solvers
+//! - [`clarabel`](solvers::clarabel) - [Clarabel](https://github.com/oxfordcontrol/Clarabel.rs)
+//!
 //!  ```rust
 //!  use good_lp::{variables, variable, default_solver, SolverModel, Solution};
 //!
@@ -123,6 +136,10 @@ pub use solvers::microlp::microlp as default_solver;
 #[cfg(feature = "scip")]
 #[cfg_attr(docsrs, doc(cfg(feature = "highs")))]
 pub use solvers::scip::scip;
+
+#[cfg(feature = "cp_sat")]
+#[cfg_attr(docsrs, doc(cfg(feature = "cp_sat")))]
+pub use solvers::cp_sat::cp_sat;
 #[cfg(not(any(
     feature = "coin_cbc",
     feature = "microlp",
@@ -131,6 +148,17 @@ pub use solvers::scip::scip;
 )))]
 #[cfg(feature = "scip")]
 pub use solvers::scip::scip as default_solver;
+
+#[cfg(not(any(
+    feature = "coin_cbc",
+    feature = "microlp",
+    feature = "lpsolve",
+    feature = "highs",
+    feature = "scip",
+)))]
+#[cfg(feature = "cp_sat")]
+/// When the "cp_sat" cargo feature is present, cp_sat is used as the default solver
+pub use solvers::cp_sat::cp_sat as default_solver;
 
 pub use solvers::{
     DualValues, ModelWithSOS1, ObjectiveDirection, ResolutionError, Solution, SolutionStatus,
@@ -162,6 +190,7 @@ pub const default_solver: LpSolver<
     feature = "scip",
     feature = "cplex-rs",
     feature = "clarabel",
+    feature = "cp_sat",
 )))]
 compile_error!(
     "No solver available. \

--- a/src/solvers/cp_sat.rs
+++ b/src/solvers/cp_sat.rs
@@ -98,11 +98,10 @@ pub fn cp_sat(to_solve: UnsolvedProblem) -> CpSatProblem {
 }
 
 /// Rounds `f64` to `i64` with saturation at the numeric limits.
-/// NaN is logged to stderr and treated as 0.
+/// Panics on NaN.
 fn round_i64(x: f64) -> i64 {
     if x.is_nan() {
-        eprintln!("Warning: CP-SAT received NaN, treating as 0.");
-        0
+        panic!("CP-SAT received NaN");
     } else if x >= i64::MAX as f64 {
         i64::MAX
     } else if x <= i64::MIN as f64 {
@@ -114,7 +113,7 @@ fn round_i64(x: f64) -> i64 {
 
 /// Translates a good_lp `VariableDefinition` into a CP-SAT `IntVar`.
 ///
-/// Bound mapping: `min`/`max` from `VariableDefinition` → CP-SAT domain interval `(lo, hi)`.
+/// Bound mapping: `min`/`max` from `VariableDefinition` to CP-SAT domain interval `(lo, hi)`.
 /// Non-finite bounds (infinity) map to `i64::MIN` / `i64::MAX`.
 fn create_cp_sat_var(
     model: &mut CpModelBuilder,
@@ -271,7 +270,7 @@ impl CpSatProblem {
     ///
     /// This can be useful if you want to clear the warm-start hints without
     /// modifying the model structure.
-    pub fn del_hints(&mut self) {
+    pub fn clear_hints(&mut self) {
         self.model.del_hints();
     }
 

--- a/src/solvers/cp_sat.rs
+++ b/src/solvers/cp_sat.rs
@@ -1,0 +1,854 @@
+//! A solver that uses the Google OR-Tools CP-SAT solver.
+//! This solver is activated using the `cp_sat` feature.
+//! You need to have the OR-Tools library installed on your system.
+//!
+//! # Limitations
+//!
+//! - CP-SAT only supports **integer** and **binary** variables.
+//!   Continuous (floating-point) variables are not supported.
+//!   Using a non-integer variable will cause a panic at model creation.
+//! - All coefficients and constants are rounded to `i64` values,
+//!   which is a limitation of the underlying CP-SAT solver.
+
+use cp_sat::builder::{CpModelBuilder, IntVar, LinearExpr};
+use cp_sat::ffi;
+use cp_sat::proto::{CpSolverResponse, CpSolverStatus, SatParameters};
+
+use crate::solvers::{MipGapError, SolutionStatus, WithInitialSolution, WithMipGap, WithTimeLimit};
+use crate::variable::{UnsolvedProblem, VariableDefinition};
+use crate::{Constraint, Variable};
+use crate::{
+    constraint::ConstraintReference,
+    solvers::{ObjectiveDirection, ResolutionError, Solution, SolverModel},
+};
+
+/// The CP-SAT [Google OR-Tools](https://developers.google.com/optimization) solver library.
+/// To be passed to [`UnsolvedProblem::using`](crate::variable::UnsolvedProblem::using)
+///
+/// # Panics
+///
+/// Panics if any variable is not an integer variable
+/// (i.e., `is_integer` is `false` on the variable definition),
+/// because CP-SAT does not support continuous variables.
+pub fn cp_sat(to_solve: UnsolvedProblem) -> CpSatProblem {
+    let UnsolvedProblem {
+        objective,
+        direction,
+        variables,
+    } = to_solve;
+
+    let mut model = CpModelBuilder::default();
+
+    // Create CP-SAT integer variables from good_lp variable definitions
+    let cp_sat_vars: Vec<IntVar> = variables
+        .iter_variables_with_def()
+        .map(|(var, def)| {
+            assert!(
+                def.is_integer,
+                "CP-SAT does not support continuous variables. \
+                 Variable {} (index {}) was not declared as integer or binary. \
+                 Please use `.integer()` or `.binary()` on the variable definition.",
+                if def.name.is_empty() {
+                    format!("v{}", var.index())
+                } else {
+                    def.name.clone()
+                },
+                var.index()
+            );
+            create_cp_sat_var(&mut model, def, var)
+        })
+        .collect();
+
+    // Build the objective expression
+    let mut objective_expr = LinearExpr::default();
+    for (var, coeff) in &objective.linear.coefficients {
+        let cp_var = cp_sat_vars[var.index()];
+        let coeff_i64 = round_i64(*coeff);
+        if coeff_i64 != 0 {
+            objective_expr += (coeff_i64, cp_var);
+        }
+    }
+
+    // Set objective direction
+    match direction {
+        ObjectiveDirection::Maximisation => {
+            model.maximize(objective_expr);
+        }
+        ObjectiveDirection::Minimisation => {
+            model.minimize(objective_expr);
+        }
+    }
+
+    // Store initial solution hints if any are set on variables
+    let mut initial_solution = Vec::with_capacity(variables.initial_solution_len());
+    for (var, def) in variables.iter_variables_with_def() {
+        if let Some(val) = def.initial {
+            initial_solution.push((var, val));
+        }
+    }
+
+    let mut problem = CpSatProblem {
+        model,
+        cp_sat_vars,
+        params: SatParameters::default(),
+    };
+
+    if !initial_solution.is_empty() {
+        problem = problem.with_initial_solution(initial_solution);
+    }
+
+    problem
+}
+
+/// Rounds an f64 value to i64, clamping to the i64 range.
+/// Warns via `eprintln!` when encountering NaN, which indicates a likely
+/// programming error (e.g., uninitialized coefficient or constant).
+fn round_i64(x: f64) -> i64 {
+    if x.is_nan() {
+        eprintln!(
+            "Warning: CP-SAT received a NaN value, treating as 0. \
+             This may indicate an uninitialized coefficient or constant in the model."
+        );
+        0
+    } else if x >= i64::MAX as f64 {
+        i64::MAX
+    } else if x <= i64::MIN as f64 {
+        i64::MIN
+    } else {
+        x.round() as i64
+    }
+}
+
+/// Creates an IntVar in the model from a VariableDefinition.
+fn create_cp_sat_var(
+    model: &mut CpModelBuilder,
+    def: &VariableDefinition,
+    var: Variable,
+) -> IntVar {
+    let name = if def.name.is_empty() {
+        format!("v{}", var.index())
+    } else {
+        def.name.clone()
+    };
+
+    // Translate bounds to CP-SAT domain
+    let domain_lower = if def.min.is_finite() {
+        round_i64(def.min)
+    } else {
+        i64::MIN
+    };
+    let domain_upper = if def.max.is_finite() {
+        round_i64(def.max)
+    } else {
+        i64::MAX
+    };
+
+    // Validate: lower bound must not exceed upper bound
+    assert!(
+        domain_lower <= domain_upper,
+        "Invalid variable bounds: lower={} > upper={} for variable '{}'",
+        def.min,
+        def.max,
+        name
+    );
+
+    let domain = [(domain_lower, domain_upper)];
+    model.new_int_var_with_name(domain, name)
+}
+
+/// A CP-SAT model
+pub struct CpSatProblem {
+    model: CpModelBuilder,
+    cp_sat_vars: Vec<IntVar>,
+    params: SatParameters,
+}
+
+impl CpSatProblem {
+    /// Get the inner CP-SAT model
+    pub fn as_inner(&self) -> &CpModelBuilder {
+        &self.model
+    }
+
+    /// Get a mutable version of the inner CP-SAT model.
+    /// good_lp will crash (but should stay memory-safe) if you change the structure of the problem
+    /// itself using this method.
+    pub fn as_inner_mut(&mut self) -> &mut CpModelBuilder {
+        &mut self.model
+    }
+
+    /// Builds a `LinearExpr` from a good_lp `Constraint`'s expression,
+    /// converting f64 coefficients to i64.
+    fn expr_from_constraint_expression(&self, expression: &crate::Expression) -> LinearExpr {
+        let mut linear = LinearExpr::default();
+        for (var, coeff) in expression.linear.coefficients.iter() {
+            let coeff_i64 = round_i64(*coeff);
+            if coeff_i64 != 0 {
+                linear += (coeff_i64, self.cp_sat_vars[var.index()]);
+            }
+        }
+        linear
+    }
+
+    /// Sets whether or not the solver should display verbose logging information to the console.
+    ///
+    /// When enabled, CP-SAT will log search progress to stdout.
+    pub fn set_verbose(mut self, verbose: bool) -> Self {
+        self.params.log_search_progress = Some(verbose);
+        self
+    }
+
+    /// Sets whether the solver log output should be captured in the solver response.
+    ///
+    /// When enabled, the log output will be available in the solution's
+    /// [`CpSatSolution::solution_log`] method. This implicitly enables
+    /// search progress logging.
+    pub fn set_log_to_response(mut self, log: bool) -> Self {
+        self.params.log_to_response = Some(log);
+        if log {
+            self.params.log_search_progress = Some(true);
+        }
+        self
+    }
+
+    /// Sets the number of search workers to use for parallel solving.
+    ///
+    /// By default, CP-SAT automatically selects the number of workers based on
+    /// the number of CPU cores. Set this to override the automatic selection.
+    ///
+    /// A value of 1 disables parallelism. Higher values may speed up solving
+    /// on multi-core systems.
+    pub fn set_num_search_workers(mut self, n: i32) -> Self {
+        self.params.num_search_workers = Some(n);
+        self
+    }
+
+    /// Sets the random seed for deterministic randomness in the solver.
+    ///
+    /// When set to a fixed value, repeated solves of the same problem will
+    /// produce identical results. A value of 0 (or not setting this) lets
+    /// the solver use non-deterministic randomness.
+    pub fn set_random_seed(mut self, seed: i32) -> Self {
+        self.params.random_seed = Some(seed);
+        self
+    }
+
+    /// Sets the absolute MIP gap tolerance.
+    ///
+    /// This stops the search when the absolute difference between the best
+    /// bound and the best objective falls below this value.
+    pub fn set_mip_abs_gap(mut self, gap: f64) -> Result<Self, MipGapError> {
+        if gap.is_sign_negative() {
+            Err(MipGapError::Negative)
+        } else if gap.is_infinite() {
+            Err(MipGapError::Infinite)
+        } else {
+            self.params.absolute_gap_limit = Some(gap);
+            Ok(self)
+        }
+    }
+
+    /// Sets whether to fill additional solutions in the response.
+    ///
+    /// When enabled, the solver will return all intermediate solutions found
+    /// during the search in the solution's
+    /// [`CpSatSolution::additional_solutions`] method.
+    pub fn set_fill_additional_solutions(mut self, fill: bool) -> Self {
+        self.params.fill_additional_solutions_in_response = Some(fill);
+        self
+    }
+
+    /// Returns a reference to the current solver parameters.
+    /// This allows direct access to all CP-SAT `SatParameters` fields.
+    pub fn params(&self) -> &SatParameters {
+        &self.params
+    }
+
+    /// Returns a mutable reference to the current solver parameters.
+    /// This allows direct modification of all CP-SAT `SatParameters` fields.
+    pub fn params_mut(&mut self) -> &mut SatParameters {
+        &mut self.params
+    }
+
+    /// Deletes all solution hints previously set via `with_initial_solution`
+    /// or via variable `.initial()` definitions.
+    ///
+    /// This can be useful if you want to clear the warm-start hints without
+    /// modifying the model structure.
+    pub fn del_hints(&mut self) {
+        self.model.del_hints();
+    }
+
+    /// Get the solver statistics as a formatted string.
+    /// This returns the model statistics even before solving.
+    pub fn model_stats(&self) -> String {
+        self.model.stats()
+    }
+}
+
+impl SolverModel for CpSatProblem {
+    type Solution = CpSatSolution;
+    type Error = ResolutionError;
+
+    fn solve(self) -> Result<Self::Solution, Self::Error> {
+        let response = self.model.solve_with_parameters(&self.params);
+
+        let has_time_limit = self.params.max_deterministic_time.is_some()
+            || self.params.max_time_in_seconds.is_some();
+        let has_gap_limit =
+            self.params.relative_gap_limit.is_some() || self.params.absolute_gap_limit.is_some();
+
+        let status = response.status();
+        let status_from_limits = || {
+            if has_time_limit {
+                SolutionStatus::TimeLimit
+            } else if has_gap_limit {
+                SolutionStatus::GapLimit
+            } else {
+                SolutionStatus::Optimal
+            }
+        };
+
+        match status {
+            CpSolverStatus::Optimal => Ok(CpSatSolution {
+                response,
+                status: SolutionStatus::Optimal,
+                cp_sat_vars: self.cp_sat_vars,
+            }),
+            CpSolverStatus::Feasible => Ok(CpSatSolution {
+                response,
+                status: status_from_limits(),
+                cp_sat_vars: self.cp_sat_vars,
+            }),
+            CpSolverStatus::Infeasible => Err(ResolutionError::Infeasible),
+            CpSolverStatus::Unknown => {
+                if !response.solution.is_empty() {
+                    Ok(CpSatSolution {
+                        response,
+                        status: status_from_limits(),
+                        cp_sat_vars: self.cp_sat_vars,
+                    })
+                } else if has_time_limit {
+                    Err(ResolutionError::Other(
+                        "Time limit reached without finding a feasible solution",
+                    ))
+                } else {
+                    Err(ResolutionError::Other(
+                        "Unknown solver status: search limit reached or other interruption",
+                    ))
+                }
+            }
+            CpSolverStatus::ModelInvalid => {
+                let validation = self.model.validate_cp_model();
+                Err(ResolutionError::Str(format!(
+                    "Invalid CP-SAT model: {}",
+                    validation
+                )))
+            }
+        }
+    }
+
+    fn add_constraint(&mut self, constraint: Constraint) -> ConstraintReference {
+        let index = self.model.proto().constraints.len();
+
+        // good_lp Constraint:
+        //   expression = sum(coeff_i * var_i) + constant
+        //   is_equality = true  => expression == 0 => sum(coeff_i * var_i) == -constant
+        //   is_equality = false => expression <= 0 => sum(coeff_i * var_i) <= -constant
+
+        let constant_i64 = round_i64(-constraint.expression.constant);
+        let linear_expr = self.expr_from_constraint_expression(&constraint.expression);
+
+        if constraint.is_equality {
+            self.model.add_eq(linear_expr, constant_i64);
+        } else {
+            self.model.add_le(linear_expr, constant_i64);
+        }
+
+        ConstraintReference { index }
+    }
+
+    fn name() -> &'static str {
+        "CP-SAT"
+    }
+}
+
+impl WithInitialSolution for CpSatProblem {
+    fn with_initial_solution(
+        mut self,
+        solution: impl IntoIterator<Item = (Variable, f64)>,
+    ) -> Self {
+        for (var, val) in solution {
+            let cp_var = self.cp_sat_vars[var.index()];
+            let hint_value = round_i64(val);
+            self.model.add_hint(cp_var, hint_value);
+        }
+        self
+    }
+}
+
+impl WithTimeLimit for CpSatProblem {
+    fn with_time_limit<T: Into<f64>>(mut self, seconds: T) -> Self {
+        self.params.max_time_in_seconds = Some(seconds.into());
+        self
+    }
+}
+
+impl WithMipGap for CpSatProblem {
+    fn mip_gap(&self) -> Option<f32> {
+        self.params.relative_gap_limit.map(|v| v as f32)
+    }
+
+    fn with_mip_gap(mut self, mip_gap: f32) -> Result<Self, MipGapError> {
+        if mip_gap.is_sign_negative() {
+            Err(MipGapError::Negative)
+        } else if mip_gap.is_infinite() {
+            Err(MipGapError::Infinite)
+        } else {
+            self.params.relative_gap_limit = Some(mip_gap as f64);
+            Ok(self)
+        }
+    }
+}
+
+/// A CP-SAT problem solution
+pub struct CpSatSolution {
+    response: CpSolverResponse,
+    status: SolutionStatus,
+    cp_sat_vars: Vec<IntVar>,
+}
+
+impl CpSatSolution {
+    /// Returns the inner solver response for advanced querying
+    pub fn response(&self) -> &CpSolverResponse {
+        &self.response
+    }
+
+    /// Returns the inner solver response, consuming the solution.
+    pub fn into_response(self) -> CpSolverResponse {
+        self.response
+    }
+
+    /// Returns the solver response statistics as a formatted string.
+    ///
+    /// This provides detailed information about the solve, including
+    /// number of conflicts, branches, propagations, wall time, etc.
+    ///
+    /// ## Format
+    ///
+    /// The output format matches the standard CP-SAT logging format:
+    ///
+    /// ```text
+    /// CpSolverResponse summary:
+    /// status: OPTIMAL
+    /// objective: 42
+    /// best_bound: 42
+    /// booleans: 5
+    /// conflicts: 23
+    /// branches: 47
+    /// propagations: 1234
+    /// walltime: 0.003
+    /// ```
+    pub fn response_stats(&self) -> String {
+        ffi::cp_solver_response_stats(&self.response, true)
+    }
+
+    /// Returns the solver log output, if `set_log_to_response` was enabled
+    /// on the problem before solving.
+    ///
+    /// The log contains the search progress information that CP-SAT normally
+    /// writes to stdout.
+    pub fn solution_log(&self) -> &str {
+        &self.response.solve_log
+    }
+
+    /// Returns the additional solutions found during search, if
+    /// `set_fill_additional_solutions` was enabled on the problem.
+    ///
+    /// The primary solution is always available through the
+    /// [`value`](Solution::value) method.
+    pub fn additional_solutions(&self) -> &[cp_sat::proto::CpSolverSolution] {
+        &self.response.additional_solutions
+    }
+}
+
+impl Solution for CpSatSolution {
+    fn status(&self) -> SolutionStatus {
+        self.status
+    }
+
+    fn value(&self, variable: Variable) -> f64 {
+        let cp_var = self.cp_sat_vars[variable.index()];
+        cp_var.solution_value(&self.response) as f64
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::cp_sat;
+    use crate::{
+        Solution, SolverModel, WithInitialSolution, constraint,
+        solvers::{SolutionStatus, WithTimeLimit},
+        variable, variables,
+    };
+
+    #[test]
+    fn solve_simple_integer_problem() {
+        let mut vars = variables!();
+        let x = vars.add(variable().integer().min(0).max(10));
+        let y = vars.add(variable().integer().min(0).max(5));
+
+        let pb = vars
+            .maximise(x + y)
+            .using(cp_sat)
+            .with(constraint!(x + 2 * y <= 10))
+            .with(constraint!(x >= 1));
+
+        let sol = pb.solve().unwrap();
+        assert_eq!(sol.status(), SolutionStatus::Optimal);
+
+        // Optimal: x=10, y=0 gives obj=10 (but x+2y<=10, so with x>=1:
+        //   x=2, y=4 gives 2+8=10, obj=6
+        //   x=4, y=3 gives 4+6=10, obj=7
+        //   x=6, y=2 gives 6+4=10, obj=8
+        //   x=8, y=1 gives 8+2=10, obj=9
+        //   x=10, y=0 gives 10+0=10, obj=10
+        // So optimal is x=10, y=0, obj=10
+        assert_eq!(sol.value(x), 10.0);
+        assert_eq!(sol.value(y), 0.0);
+    }
+
+    #[test]
+    fn solve_binary_problem() {
+        let mut vars = variables!();
+        let x = vars.add(variable().binary());
+        let y = vars.add(variable().binary());
+
+        let pb = vars
+            .maximise(x + y)
+            .using(cp_sat)
+            .with(constraint!(x + y <= 1));
+
+        let sol = pb.solve().unwrap();
+        assert_eq!(sol.status(), SolutionStatus::Optimal);
+
+        // Solutions: (1,0) or (0,1) both give obj=1
+        assert_eq!(sol.value(x) + sol.value(y), 1.0);
+    }
+
+    #[test]
+    fn solve_with_equality_constraint() {
+        let mut vars = variables!();
+        let x = vars.add(variable().integer().min(0).max(10));
+        let y = vars.add(variable().integer().min(0).max(10));
+
+        let pb = vars.maximise(x + y).using(cp_sat).with(constraint!(x == y));
+
+        let sol = pb.solve().unwrap();
+        assert_eq!(sol.status(), SolutionStatus::Optimal);
+        assert_eq!(sol.value(x), 10.0);
+        assert_eq!(sol.value(y), 10.0);
+    }
+
+    #[test]
+    fn solve_minimization_problem() {
+        let mut vars = variables!();
+        let x = vars.add(variable().integer().min(0).max(10));
+
+        let pb = vars.minimise(x).using(cp_sat).with(constraint!(x >= 3));
+
+        let sol = pb.solve().unwrap();
+        assert_eq!(sol.status(), SolutionStatus::Optimal);
+        assert_eq!(sol.value(x), 3.0);
+    }
+
+    #[test]
+    fn solve_infeasible_problem() {
+        let mut vars = variables!();
+        let x = vars.add(variable().integer().min(0).max(5));
+        let y = vars.add(variable().integer().min(0).max(5));
+
+        let pb = vars
+            .maximise(x + y)
+            .using(cp_sat)
+            .with(constraint!(x + y >= 20));
+
+        let result = pb.solve();
+        assert!(result.is_err());
+        assert_eq!(result.err().unwrap(), crate::ResolutionError::Infeasible);
+    }
+
+    #[test]
+    fn solve_problem_with_time_limit() {
+        let mut vars = variables!();
+        let x = vars.add(variable().binary());
+
+        let pb = vars.maximise(x).using(cp_sat).with_time_limit(10.0);
+
+        let sol = pb.solve().unwrap();
+        assert_eq!(sol.value(x), 1.0);
+    }
+
+    #[test]
+    fn solve_problem_with_initial_solution() {
+        let mut vars = variables!();
+        let x = vars.add(variable().integer().min(0).max(10));
+        let y = vars.add(variable().integer().min(0).max(10));
+
+        let pb = vars
+            .maximise(x + y)
+            .using(cp_sat)
+            .with(constraint!(x + y <= 5))
+            .with_initial_solution(vec![(x, 2.0), (y, 3.0)]);
+
+        let sol = pb.solve().unwrap();
+        assert_eq!(sol.status(), SolutionStatus::Optimal);
+        assert_eq!(sol.value(x) + sol.value(y), 5.0);
+    }
+
+    #[test]
+    fn solve_problem_with_initial_variable_values() {
+        let mut vars = variables!();
+        let x = vars.add(variable().integer().min(0).max(10).initial(5));
+        let y = vars.add(variable().integer().min(0).max(10).initial(5));
+
+        let pb = vars
+            .maximise(x + y)
+            .using(cp_sat)
+            .with(constraint!(x + y <= 8));
+
+        let sol = pb.solve().unwrap();
+        assert_eq!(sol.status(), SolutionStatus::Optimal);
+        assert_eq!(sol.value(x) + sol.value(y), 8.0);
+    }
+
+    #[test]
+    #[should_panic(expected = "does not support continuous variables")]
+    fn test_continuous_var_panics() {
+        let mut vars = variables!();
+        let _x = vars.add(variable().min(0).max(10)); // not integer
+        let pb = vars.maximise(_x).using(cp_sat);
+        let _ = pb.solve();
+    }
+
+    #[test]
+    fn solve_with_large_coefficients() {
+        let mut vars = variables!();
+        let x = vars.add(variable().integer().min(0).max(100));
+
+        // Use coefficients that require rounding
+        let pb = vars
+            .maximise(3 * x + 2 * x)
+            .using(cp_sat)
+            .with(constraint!(x <= 42));
+
+        let sol = pb.solve().unwrap();
+        assert_eq!(sol.status(), SolutionStatus::Optimal);
+        assert_eq!(sol.value(x), 42.0);
+    }
+
+    #[test]
+    fn solve_with_verbose_logging() {
+        let mut vars = variables!();
+        let x = vars.add(variable().integer().min(0).max(10));
+
+        let pb = vars.maximise(x).using(cp_sat).set_verbose(true);
+
+        let sol = pb.solve().unwrap();
+        assert_eq!(sol.status(), SolutionStatus::Optimal);
+        assert_eq!(sol.value(x), 10.0);
+    }
+
+    #[test]
+    fn solve_with_log_to_response() {
+        let mut vars = variables!();
+        let x = vars.add(variable().integer().min(0).max(10));
+
+        let pb = vars.maximise(x).using(cp_sat).set_log_to_response(true);
+
+        let sol = pb.solve().unwrap();
+        assert_eq!(sol.status(), SolutionStatus::Optimal);
+        // solution_log name is included in the response
+        assert!(
+            sol.solution_log().contains("OPTIMAL")
+                || sol.solution_log().contains("objective")
+                || sol.solution_log().is_empty(), // CP-SAT may not populate solve_log
+        );
+    }
+
+    #[test]
+    fn solve_with_num_search_workers() {
+        let mut vars = variables!();
+        let x = vars.add(variable().integer().min(0).max(10));
+        let y = vars.add(variable().integer().min(0).max(5));
+
+        let pb = vars
+            .maximise(x + y)
+            .using(cp_sat)
+            .with(constraint!(x + 2 * y <= 10))
+            .set_num_search_workers(2);
+
+        let sol = pb.solve().unwrap();
+        assert_eq!(sol.status(), SolutionStatus::Optimal);
+        assert_eq!(sol.value(x), 10.0);
+        assert_eq!(sol.value(y), 0.0);
+    }
+
+    #[test]
+    fn solve_with_random_seed() {
+        let mut vars = variables!();
+        let x = vars.add(variable().integer().min(0).max(10));
+        let y = vars.add(variable().integer().min(0).max(5));
+
+        let pb = vars
+            .maximise(x + y)
+            .using(cp_sat)
+            .with(constraint!(x + 2 * y <= 10))
+            .set_random_seed(42);
+
+        let sol = pb.solve().unwrap();
+        assert_eq!(sol.status(), SolutionStatus::Optimal);
+        assert_eq!(sol.value(x), 10.0);
+        assert_eq!(sol.value(y), 0.0);
+    }
+
+    #[test]
+    fn solve_with_mip_abs_gap() {
+        let mut vars = variables!();
+        let x = vars.add(variable().integer().min(0).max(10));
+        let y = vars.add(variable().integer().min(0).max(5));
+
+        let pb = vars
+            .maximise(x + y)
+            .using(cp_sat)
+            .with(constraint!(x + 2 * y <= 10))
+            .set_mip_abs_gap(0.01)
+            .unwrap();
+
+        let sol = pb.solve().unwrap();
+        assert_eq!(sol.status(), SolutionStatus::Optimal);
+        assert_eq!(sol.value(x), 10.0);
+    }
+
+    #[test]
+    fn solve_with_mip_abs_gap_negative_errors() {
+        let pb = cp_sat(variables!().maximise(0));
+        let result = pb.set_mip_abs_gap(-1.0);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn solve_with_mip_abs_gap_infinite_errors() {
+        let pb = cp_sat(variables!().maximise(0));
+        let result = pb.set_mip_abs_gap(f64::INFINITY);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn solve_with_response_stats() {
+        let mut vars = variables!();
+        let x = vars.add(variable().integer().min(0).max(10));
+
+        let pb = vars.maximise(x).using(cp_sat);
+
+        let sol = pb.solve().unwrap();
+        let stats = sol.response_stats();
+        // The stats string should be non-empty and contain status information
+        assert!(!stats.is_empty());
+        // It should mention OPTIMAL since we got an optimal solution
+        assert!(
+            stats.contains("OPTIMAL") || stats.contains("optimal"),
+            "response_stats should mention OPTIMAL, got: {stats}"
+        );
+    }
+
+    #[test]
+    fn solve_with_model_stats() {
+        let mut vars = variables!();
+        let x = vars.add(variable().integer().min(0).max(10));
+
+        let pb = vars.maximise(x).using(cp_sat);
+
+        let stats = pb.model_stats();
+        assert!(
+            !stats.is_empty(),
+            "model_stats should not be empty, got: {stats}"
+        );
+    }
+
+    #[test]
+    fn solve_with_params_access() {
+        let mut vars = variables!();
+        let x = vars.add(variable().integer().min(0).max(10));
+
+        let pb = vars
+            .maximise(x)
+            .using(cp_sat)
+            .set_num_search_workers(4)
+            .set_random_seed(99);
+
+        // Check that params are accessible
+        assert_eq!(pb.params().num_search_workers, Some(4));
+        assert_eq!(pb.params().random_seed, Some(99));
+
+        let sol = pb.solve().unwrap();
+        assert_eq!(sol.value(x), 10.0);
+    }
+
+    #[test]
+    fn solve_with_mip_gap_trait() {
+        use crate::solvers::WithMipGap;
+
+        let mut vars = variables!();
+        let x = vars.add(variable().integer().min(0).max(10));
+
+        let pb = vars.maximise(x).using(cp_sat).with_mip_gap(0.05).unwrap();
+
+        // The mip_gap should be accessible
+        assert_eq!(pb.mip_gap(), Some(0.05));
+
+        let sol = pb.solve().unwrap();
+        assert_eq!(sol.value(x), 10.0);
+    }
+
+    #[test]
+    fn solve_and_into_response() {
+        let mut vars = variables!();
+        let x = vars.add(variable().integer().min(0).max(10));
+
+        let pb = vars.maximise(x).using(cp_sat);
+
+        let sol = pb.solve().unwrap();
+        let response = sol.into_response();
+        assert!(!response.solution.is_empty());
+    }
+
+    #[test]
+    fn solve_with_time_limit_via_params() {
+        let mut vars = variables!();
+        let x = vars.add(variable().binary());
+
+        // Use params_mut to set time limit directly
+        let mut pb = vars.maximise(x).using(cp_sat);
+        pb.params_mut().max_deterministic_time = Some(10.0);
+
+        let sol = pb.solve().unwrap();
+        assert_eq!(sol.value(x), 1.0);
+    }
+
+    #[test]
+    fn solve_with_verbose_and_response_log() {
+        // Test that both verbose and log_to_response can be combined
+        let mut vars = variables!();
+        let x = vars.add(variable().integer().min(0).max(10));
+
+        let pb = vars
+            .maximise(x)
+            .using(cp_sat)
+            .set_verbose(true)
+            .set_log_to_response(true);
+
+        let sol = pb.solve().unwrap();
+        assert_eq!(sol.status(), SolutionStatus::Optimal);
+        assert_eq!(sol.value(x), 10.0);
+    }
+}

--- a/src/solvers/cp_sat.rs
+++ b/src/solvers/cp_sat.rs
@@ -118,22 +118,16 @@ fn round_i64(x: f64) -> i64 {
 fn create_cp_sat_var(
     model: &mut CpModelBuilder,
     def: &VariableDefinition,
-    var: Variable,
+    _var: Variable,
 ) -> IntVar {
-    let name = if def.name.is_empty() {
-        format!("v{}", var.index())
-    } else {
-        def.name.clone()
-    };
-
     // Translate bounds to CP-SAT domain
     let domain_lower = if def.min.is_finite() {
-        round_i64(def.min)
+        def.min.ceil() as i64
     } else {
         i64::MIN
     };
     let domain_upper = if def.max.is_finite() {
-        round_i64(def.max)
+        def.max.floor() as i64
     } else {
         i64::MAX
     };
@@ -141,14 +135,16 @@ fn create_cp_sat_var(
     // Validate: lower bound must not exceed upper bound
     assert!(
         domain_lower <= domain_upper,
-        "Invalid variable bounds: lower={} > upper={} for variable '{}'",
+        "Invalid variable bounds: lower={} > upper={}",
         def.min,
-        def.max,
-        name
+        def.max
     );
 
     let domain = [(domain_lower, domain_upper)];
-    model.new_int_var_with_name(domain, name)
+    match def.name.as_str() {
+        "" => model.new_int_var(domain),
+        name => model.new_int_var_with_name(domain, name),
+    }
 }
 
 /// A CP-SAT model wrapping `CpModelBuilder`, with a linear objective,

--- a/src/solvers/cp_sat.rs
+++ b/src/solvers/cp_sat.rs
@@ -1,14 +1,11 @@
-//! A solver that uses the Google OR-Tools CP-SAT solver.
-//! This solver is activated using the `cp_sat` feature.
-//! You need to have the OR-Tools library installed on your system.
+//! A solver bridge to the Google OR-Tools CP-SAT solver, activated via the `cp_sat` feature.
 //!
 //! # Limitations
 //!
-//! - CP-SAT only supports **integer** and **binary** variables.
-//!   Continuous (floating-point) variables are not supported.
-//!   Using a non-integer variable will cause a panic at model creation.
-//! - All coefficients and constants are rounded to `i64` values,
-//!   which is a limitation of the underlying CP-SAT solver.
+//! - CP-SAT only supports **integer** and **binary** variables. Continuous (floating-point)
+//!   variables cause a panic at model creation.
+//! - All coefficients and constants are rounded to `i64`, a consequence of CP-SAT's
+//!   integer-only arithmetic.
 
 use cp_sat::builder::{CpModelBuilder, IntVar, LinearExpr};
 use cp_sat::ffi;
@@ -100,15 +97,11 @@ pub fn cp_sat(to_solve: UnsolvedProblem) -> CpSatProblem {
     problem
 }
 
-/// Rounds an f64 value to i64, clamping to the i64 range.
-/// Warns via `eprintln!` when encountering NaN, which indicates a likely
-/// programming error (e.g., uninitialized coefficient or constant).
+/// Rounds `f64` to `i64` with saturation at the numeric limits.
+/// NaN is logged to stderr and treated as 0.
 fn round_i64(x: f64) -> i64 {
     if x.is_nan() {
-        eprintln!(
-            "Warning: CP-SAT received a NaN value, treating as 0. \
-             This may indicate an uninitialized coefficient or constant in the model."
-        );
+        eprintln!("Warning: CP-SAT received NaN, treating as 0.");
         0
     } else if x >= i64::MAX as f64 {
         i64::MAX
@@ -119,7 +112,10 @@ fn round_i64(x: f64) -> i64 {
     }
 }
 
-/// Creates an IntVar in the model from a VariableDefinition.
+/// Translates a good_lp `VariableDefinition` into a CP-SAT `IntVar`.
+///
+/// Bound mapping: `min`/`max` from `VariableDefinition` → CP-SAT domain interval `(lo, hi)`.
+/// Non-finite bounds (infinity) map to `i64::MIN` / `i64::MAX`.
 fn create_cp_sat_var(
     model: &mut CpModelBuilder,
     def: &VariableDefinition,
@@ -156,7 +152,11 @@ fn create_cp_sat_var(
     model.new_int_var_with_name(domain, name)
 }
 
-/// A CP-SAT model
+/// A CP-SAT model wrapping `CpModelBuilder`, with a linear objective,
+/// variable mappings, and solver parameters. Constructed via [`cp_sat()`].
+///
+/// See the [module-level documentation](self) for constraint translation
+/// semantics and status mapping details.
 pub struct CpSatProblem {
     model: CpModelBuilder,
     cp_sat_vars: Vec<IntVar>,
@@ -164,16 +164,13 @@ pub struct CpSatProblem {
 }
 
 impl CpSatProblem {
-    /// Get the inner CP-SAT model
+    /// Returns a shared reference to the inner CP-SAT model for inspection.
+    ///
+    /// This is useful for accessing read-only model data (e.g., [`CpModelBuilder::proto`]).
+    /// To customize solver parameters, use [`params`](Self::params) or [`params_mut`](Self::params_mut)
+    /// instead.
     pub fn as_inner(&self) -> &CpModelBuilder {
         &self.model
-    }
-
-    /// Get a mutable version of the inner CP-SAT model.
-    /// good_lp will crash (but should stay memory-safe) if you change the structure of the problem
-    /// itself using this method.
-    pub fn as_inner_mut(&mut self) -> &mut CpModelBuilder {
-        &mut self.model
     }
 
     /// Builds a `LinearExpr` from a good_lp `Constraint`'s expression,
@@ -410,7 +407,13 @@ impl WithMipGap for CpSatProblem {
     }
 }
 
-/// A CP-SAT problem solution
+/// The result of solving a CP-SAT model.
+///
+/// Wraps a `CpSolverResponse` and provides access to variable values via the
+/// [`Solution`] trait, as well as solver metadata (statistics, logs, additional solutions).
+///
+/// See the [module-level documentation](self) for the status mapping from
+/// `CpSolverStatus` to [`SolutionStatus`] / [`ResolutionError`].
 pub struct CpSatSolution {
     response: CpSolverResponse,
     status: SolutionStatus,
@@ -506,13 +509,7 @@ mod tests {
         let sol = pb.solve().unwrap();
         assert_eq!(sol.status(), SolutionStatus::Optimal);
 
-        // Optimal: x=10, y=0 gives obj=10 (but x+2y<=10, so with x>=1:
-        //   x=2, y=4 gives 2+8=10, obj=6
-        //   x=4, y=3 gives 4+6=10, obj=7
-        //   x=6, y=2 gives 6+4=10, obj=8
-        //   x=8, y=1 gives 8+2=10, obj=9
-        //   x=10, y=0 gives 10+0=10, obj=10
-        // So optimal is x=10, y=0, obj=10
+        // x=10, y=0 attains the upper bound 10 of x+2y≤10, maximizing x+y.
         assert_eq!(sol.value(x), 10.0);
         assert_eq!(sol.value(y), 0.0);
     }

--- a/src/solvers/cp_sat.rs
+++ b/src/solvers/cp_sat.rs
@@ -378,18 +378,15 @@ impl SolverModel for CpSatProblem {
                 let has_gap_limit = self.solver_params.relative_gap_limit.is_some()
                     || self.solver_params.absolute_gap_limit.is_some();
 
-                let status = response.status();
-                let status_from_limits = || {
-                    if has_time_limit {
-                        SolutionStatus::TimeLimit
-                    } else if has_gap_limit {
-                        SolutionStatus::GapLimit
-                    } else {
-                        SolutionStatus::Optimal
-                    }
+                let status_from_limits = if has_time_limit {
+                    SolutionStatus::TimeLimit
+                } else if has_gap_limit {
+                    SolutionStatus::GapLimit
+                } else {
+                    SolutionStatus::Optimal
                 };
 
-                match status {
+                match response.status() {
                     CpSolverStatus::Optimal => Ok(CpSatSolution {
                         response,
                         status: SolutionStatus::Optimal,
@@ -397,7 +394,7 @@ impl SolverModel for CpSatProblem {
                     }),
                     CpSolverStatus::Feasible => Ok(CpSatSolution {
                         response,
-                        status: status_from_limits(),
+                        status: status_from_limits,
                         cp_sat_vars,
                     }),
                     CpSolverStatus::Infeasible => Err(ResolutionError::Infeasible),
@@ -405,7 +402,7 @@ impl SolverModel for CpSatProblem {
                         if !response.solution.is_empty() {
                             Ok(CpSatSolution {
                                 response,
-                                status: status_from_limits(),
+                                status: status_from_limits,
                                 cp_sat_vars,
                             })
                         } else if has_time_limit {

--- a/src/solvers/cp_sat.rs
+++ b/src/solvers/cp_sat.rs
@@ -3,9 +3,10 @@
 //! # Limitations
 //!
 //! - CP-SAT only supports **integer** and **binary** variables. Continuous (floating-point)
-//!   variables cause a panic at model creation.
-//! - All coefficients and constants are rounded to `i64`, a consequence of CP-SAT's
-//!   integer-only arithmetic.
+//!   variables cause an error at solve time.
+//! - All coefficients and constants must be integers. Non-integer values cause an error
+//!   at solve time, because CP-SAT uses integer-only arithmetic. Users should round or
+//!   scale their coefficients on their own side.
 
 use cp_sat::builder::{CpModelBuilder, IntVar, LinearExpr};
 use cp_sat::ffi;
@@ -22,11 +23,13 @@ use crate::{
 /// The CP-SAT [Google OR-Tools](https://developers.google.com/optimization) solver library.
 /// To be passed to [`UnsolvedProblem::using`](crate::variable::UnsolvedProblem::using)
 ///
-/// # Panics
+/// # Errors
 ///
-/// Panics if any variable is not an integer variable
-/// (i.e., `is_integer` is `false` on the variable definition),
-/// because CP-SAT does not support continuous variables.
+/// Returns a [`ResolutionError`] at solve time if:
+/// - Any variable is not an integer variable (i.e., `is_integer` is `false` on the variable definition),
+///   because CP-SAT does not support continuous variables.
+/// - Any variable has invalid bounds where the lower bound exceeds the upper bound.
+/// - Any coefficient or constant is `NaN` or not an integer (CP-SAT only accepts integer arithmetic).
 pub fn cp_sat(to_solve: UnsolvedProblem) -> CpSatProblem {
     let UnsolvedProblem {
         objective,
@@ -35,34 +38,44 @@ pub fn cp_sat(to_solve: UnsolvedProblem) -> CpSatProblem {
     } = to_solve;
 
     let mut model = CpModelBuilder::default();
+    let solver_params = SatParameters::default();
 
-    // Create CP-SAT integer variables from good_lp variable definitions
-    let cp_sat_vars: Vec<IntVar> = variables
-        .iter_variables_with_def()
-        .map(|(var, def)| {
-            assert!(
-                def.is_integer,
-                "CP-SAT does not support continuous variables. \
-                 Variable {} (index {}) was not declared as integer or binary. \
-                 Please use `.integer()` or `.binary()` on the variable definition.",
-                if def.name.is_empty() {
-                    format!("v{}", var.index())
-                } else {
-                    def.name.clone()
-                },
-                var.index()
+    // Phase 1: Validate all variable definitions and create CP-SAT integer variables.
+    // If any variable is invalid, transition to Invalid immediately.
+    let mut cp_sat_vars = Vec::with_capacity(variables.len());
+    for (var, def) in variables.iter_variables_with_def() {
+        if !def.is_integer {
+            return CpSatProblem::invalid(
+                ResolutionError::Str(format!(
+                    "CP-SAT does not support continuous variables. \
+                         Variable '{}' (index {}) was not declared as integer or binary. \
+                         Please use `.integer()` or `.binary()` on the variable definition.",
+                    def.name,
+                    var.index()
+                )),
+                solver_params,
             );
-            create_cp_sat_var(&mut model, def, var)
-        })
-        .collect();
+        }
 
-    // Build the objective expression
+        match create_cp_sat_var(&mut model, def, var) {
+            Ok(cp_var) => cp_sat_vars.push(cp_var),
+            Err(e) => {
+                return CpSatProblem::invalid(e, solver_params);
+            }
+        }
+    }
+
+    // Phase 2: Build the objective expression, checking for NaN coefficients.
     let mut objective_expr = LinearExpr::default();
     for (var, coeff) in &objective.linear.coefficients {
-        let cp_var = cp_sat_vars[var.index()];
-        let coeff_i64 = round_i64(*coeff);
-        if coeff_i64 != 0 {
-            objective_expr += (coeff_i64, cp_var);
+        match verify_integer(*coeff) {
+            Ok(coeff_i64) => {
+                let cp_var = cp_sat_vars[var.index()];
+                objective_expr += (coeff_i64, cp_var);
+            }
+            Err(e) => {
+                return CpSatProblem::invalid(e, solver_params);
+            }
         }
     }
 
@@ -76,74 +89,143 @@ pub fn cp_sat(to_solve: UnsolvedProblem) -> CpSatProblem {
         }
     }
 
-    // Store initial solution hints if any are set on variables
-    let mut initial_solution = Vec::with_capacity(variables.initial_solution_len());
-    for (var, def) in variables.iter_variables_with_def() {
-        if let Some(val) = def.initial {
-            initial_solution.push((var, val));
-        }
-    }
+    // Phase 3: Collect initial solution hints (skip non-finite values)
+    let initial_solution: Vec<(Variable, f64)> = variables
+        .iter_variables_with_def()
+        .filter_map(|(var, def)| def.initial.filter(|v| v.is_finite()).map(|v| (var, v)))
+        .collect();
 
     let mut problem = CpSatProblem {
-        model,
-        cp_sat_vars,
-        params: SatParameters::default(),
+        state: ProblemState::Valid { model, cp_sat_vars },
+        solver_params,
     };
 
-    if !initial_solution.is_empty() {
-        problem = problem.with_initial_solution(initial_solution);
-    }
+    problem = problem.with_initial_solution(initial_solution);
 
     problem
 }
 
-/// Rounds `f64` to `i64` with saturation at the numeric limits.
-/// Panics on NaN.
-fn round_i64(x: f64) -> i64 {
-    if x.is_nan() {
-        panic!("CP-SAT received NaN");
-    } else if x >= i64::MAX as f64 {
-        i64::MAX
-    } else if x <= i64::MIN as f64 {
-        i64::MIN
+/// Verifies that an `f64` value is a finite integer representable as `i64`.
+///
+/// Returns an error if the value is non-finite, has a non-zero fractional part,
+/// or is outside the `i64` representable range.
+///
+/// This is used for coefficients, constants, and variable bounds — CP-SAT requires
+/// all of them to be finite integers.
+fn verify_integer(x: f64) -> Result<i64, ResolutionError> {
+    if !x.is_finite() {
+        return Err(ResolutionError::Str(format!(
+            "The CP-SAT solver does not accept infinite values for coefficients, constants, \
+             or variable bounds. Received `{x}`, which is not finite."
+        )));
+    }
+    if x.fract() != 0.0 {
+        return Err(ResolutionError::Str(format!(
+            "The CP-SAT solver only accepts integer values for coefficients, constants, \
+             or variable bounds. Received `{x}`, which is not an integer. \
+             Please round or scale your values to integers."
+        )));
+    }
+    if !(x >= -(2f64.powi(63)) && x < 2f64.powi(63)) {
+        return Err(ResolutionError::Str(format!(
+            "The CP-SAT solver value `{x}` is out of the i64 range."
+        )));
+    }
+    Ok(x as i64)
+}
+
+/// Builds a `LinearExpr` from a good_lp `Constraint`'s expression,
+/// converting f64 coefficients to i64.
+fn expr_from_constraint_expression(
+    cp_sat_vars: &[IntVar],
+    expression: &crate::Expression,
+) -> Result<LinearExpr, ResolutionError> {
+    let mut linear = LinearExpr::default();
+    for (var, coeff) in expression.linear.coefficients.iter() {
+        let coeff_i64 = verify_integer(*coeff)?;
+        if coeff_i64 != 0 {
+            linear += (coeff_i64, cp_sat_vars[var.index()]);
+        }
+    }
+    Ok(linear)
+}
+
+/// Validates that a MIP gap value is valid (non-negative and finite).
+fn validate_gap(gap: f64) -> Result<(), MipGapError> {
+    if gap.is_sign_negative() {
+        Err(MipGapError::Negative)
+    } else if gap.is_infinite() {
+        Err(MipGapError::Infinite)
     } else {
-        x.round() as i64
+        Ok(())
     }
 }
 
 /// Translates a good_lp `VariableDefinition` into a CP-SAT `IntVar`.
 ///
-/// Bound mapping: `min`/`max` from `VariableDefinition` to CP-SAT domain interval `(lo, hi)`.
-/// Non-finite bounds (infinity) map to `i64::MIN` / `i64::MAX`.
+/// All bounds are validated through [`verify_integer`] — they must be finite integers.
+///
+/// Returns an error if the lower bound exceeds the upper bound.
 fn create_cp_sat_var(
     model: &mut CpModelBuilder,
     def: &VariableDefinition,
     _var: Variable,
-) -> IntVar {
-    // Translate bounds to CP-SAT domain
-    let domain_lower = if def.min.is_finite() {
-        def.min.ceil() as i64
-    } else {
-        i64::MIN
-    };
-    let domain_upper = if def.max.is_finite() {
-        def.max.floor() as i64
-    } else {
-        i64::MAX
-    };
+) -> Result<IntVar, ResolutionError> {
+    // Translate bounds to CP-SAT domain via verify_integer (rejects non-finite, non-integer values)
+    let domain_lower = verify_integer(def.min)?;
+    let domain_upper = verify_integer(def.max)?;
 
     // Validate: lower bound must not exceed upper bound
-    assert!(
-        domain_lower <= domain_upper,
-        "Invalid variable bounds: lower={} > upper={}",
-        def.min,
-        def.max
-    );
+    if domain_lower > domain_upper {
+        return Err(ResolutionError::Str(if def.name.is_empty() {
+            format!(
+                "Invalid bounds for variable (index {}): lower bound ({}) > upper bound ({})",
+                _var.index(),
+                def.min,
+                def.max
+            )
+        } else {
+            format!(
+                "Invalid bounds for variable '{}': lower bound ({}) > upper bound ({})",
+                def.name, def.min, def.max
+            )
+        }));
+    }
 
     let domain = [(domain_lower, domain_upper)];
     match def.name.as_str() {
-        "" => model.new_int_var(domain),
-        name => model.new_int_var_with_name(domain, name),
+        "" => Ok(model.new_int_var(domain)),
+        name => Ok(model.new_int_var_with_name(domain, name)),
+    }
+}
+
+/// Internal state of a CP-SAT problem.
+///
+/// Either carries a fully valid model ready for solving, or an error description.
+/// Once in the `Invalid` state, there is no way to transition back to `Valid`.
+///
+/// In the `Invalid` state, a monotonic counter tracks constraint indices so that
+/// each "dropped" constraint still receives a unique `ConstraintReference` index.
+enum ProblemState {
+    Valid {
+        model: CpModelBuilder,
+        cp_sat_vars: Vec<IntVar>,
+    },
+    Invalid {
+        reason: ResolutionError,
+        next_constraint_index: usize,
+    },
+}
+
+impl ProblemState {
+    /// Transitions to `Invalid` if currently `Valid`. No-op if already `Invalid`.
+    fn into_invalid(&mut self, reason: ResolutionError, next_constraint_index: usize) {
+        if !matches!(self, ProblemState::Invalid { .. }) {
+            *self = ProblemState::Invalid {
+                reason,
+                next_constraint_index,
+            };
+        }
     }
 }
 
@@ -152,40 +234,45 @@ fn create_cp_sat_var(
 ///
 /// See the [module-level documentation](self) for constraint translation
 /// semantics and status mapping details.
+///
+/// Internally represented as a state machine: either `Valid` (ready to solve)
+/// or `Invalid` (error encountered during construction). Once invalid,
+/// the error is surfaced at [`solve()`](SolverModel::solve) time.
 pub struct CpSatProblem {
-    model: CpModelBuilder,
-    cp_sat_vars: Vec<IntVar>,
-    params: SatParameters,
+    state: ProblemState,
+    solver_params: SatParameters,
 }
 
 impl CpSatProblem {
-    /// Returns a shared reference to the inner CP-SAT model for inspection.
+    /// Constructs a problem in the invalid state with the given error.
+    fn invalid(reason: ResolutionError, solver_params: SatParameters) -> Self {
+        CpSatProblem {
+            state: ProblemState::Invalid {
+                reason,
+                next_constraint_index: 0,
+            },
+            solver_params,
+        }
+    }
+
+    /// Returns a shared reference to the inner CP-SAT model for inspection,
+    /// or `None` if the problem is in an invalid state.
     ///
     /// This is useful for accessing read-only model data (e.g., [`CpModelBuilder::proto`]).
     /// To customize solver parameters, use [`params`](Self::params) or [`params_mut`](Self::params_mut)
     /// instead.
-    pub fn as_inner(&self) -> &CpModelBuilder {
-        &self.model
-    }
-
-    /// Builds a `LinearExpr` from a good_lp `Constraint`'s expression,
-    /// converting f64 coefficients to i64.
-    fn expr_from_constraint_expression(&self, expression: &crate::Expression) -> LinearExpr {
-        let mut linear = LinearExpr::default();
-        for (var, coeff) in expression.linear.coefficients.iter() {
-            let coeff_i64 = round_i64(*coeff);
-            if coeff_i64 != 0 {
-                linear += (coeff_i64, self.cp_sat_vars[var.index()]);
-            }
+    pub fn as_inner(&self) -> Option<&CpModelBuilder> {
+        match &self.state {
+            ProblemState::Valid { model, .. } => Some(model),
+            ProblemState::Invalid { .. } => None,
         }
-        linear
     }
 
     /// Sets whether or not the solver should display verbose logging information to the console.
     ///
     /// When enabled, CP-SAT will log search progress to stdout.
     pub fn set_verbose(mut self, verbose: bool) -> Self {
-        self.params.log_search_progress = Some(verbose);
+        self.solver_params.log_search_progress = Some(verbose);
         self
     }
 
@@ -195,9 +282,9 @@ impl CpSatProblem {
     /// [`CpSatSolution::solution_log`] method. This implicitly enables
     /// search progress logging.
     pub fn set_log_to_response(mut self, log: bool) -> Self {
-        self.params.log_to_response = Some(log);
+        self.solver_params.log_to_response = Some(log);
         if log {
-            self.params.log_search_progress = Some(true);
+            self.solver_params.log_search_progress = Some(true);
         }
         self
     }
@@ -210,7 +297,7 @@ impl CpSatProblem {
     /// A value of 1 disables parallelism. Higher values may speed up solving
     /// on multi-core systems.
     pub fn set_num_search_workers(mut self, n: i32) -> Self {
-        self.params.num_search_workers = Some(n);
+        self.solver_params.num_search_workers = Some(n);
         self
     }
 
@@ -220,7 +307,7 @@ impl CpSatProblem {
     /// produce identical results. A value of 0 (or not setting this) lets
     /// the solver use non-deterministic randomness.
     pub fn set_random_seed(mut self, seed: i32) -> Self {
-        self.params.random_seed = Some(seed);
+        self.solver_params.random_seed = Some(seed);
         self
     }
 
@@ -229,14 +316,9 @@ impl CpSatProblem {
     /// This stops the search when the absolute difference between the best
     /// bound and the best objective falls below this value.
     pub fn set_mip_abs_gap(mut self, gap: f64) -> Result<Self, MipGapError> {
-        if gap.is_sign_negative() {
-            Err(MipGapError::Negative)
-        } else if gap.is_infinite() {
-            Err(MipGapError::Infinite)
-        } else {
-            self.params.absolute_gap_limit = Some(gap);
-            Ok(self)
-        }
+        validate_gap(gap)?;
+        self.solver_params.absolute_gap_limit = Some(gap);
+        Ok(self)
     }
 
     /// Sets whether to fill additional solutions in the response.
@@ -245,20 +327,20 @@ impl CpSatProblem {
     /// during the search in the solution's
     /// [`CpSatSolution::additional_solutions`] method.
     pub fn set_fill_additional_solutions(mut self, fill: bool) -> Self {
-        self.params.fill_additional_solutions_in_response = Some(fill);
+        self.solver_params.fill_additional_solutions_in_response = Some(fill);
         self
     }
 
     /// Returns a reference to the current solver parameters.
     /// This allows direct access to all CP-SAT `SatParameters` fields.
     pub fn params(&self) -> &SatParameters {
-        &self.params
+        &self.solver_params
     }
 
     /// Returns a mutable reference to the current solver parameters.
     /// This allows direct modification of all CP-SAT `SatParameters` fields.
     pub fn params_mut(&mut self) -> &mut SatParameters {
-        &mut self.params
+        &mut self.solver_params
     }
 
     /// Deletes all solution hints previously set via `with_initial_solution`
@@ -267,13 +349,17 @@ impl CpSatProblem {
     /// This can be useful if you want to clear the warm-start hints without
     /// modifying the model structure.
     pub fn clear_hints(&mut self) {
-        self.model.del_hints();
+        if let ProblemState::Valid { model, .. } = &mut self.state {
+            model.del_hints();
+        }
     }
 
     /// Get the solver statistics as a formatted string.
     /// This returns the model statistics even before solving.
-    pub fn model_stats(&self) -> String {
-        self.model.stats()
+    ///
+    /// Returns `None` if the problem is in an invalid state.
+    pub fn model_stats(&self) -> Option<String> {
+        self.as_inner().map(|model| model.stats())
     }
 }
 
@@ -282,81 +368,108 @@ impl SolverModel for CpSatProblem {
     type Error = ResolutionError;
 
     fn solve(self) -> Result<Self::Solution, Self::Error> {
-        let response = self.model.solve_with_parameters(&self.params);
+        match self.state {
+            ProblemState::Invalid { reason, .. } => Err(reason),
+            ProblemState::Valid { model, cp_sat_vars } => {
+                let response = model.solve_with_parameters(&self.solver_params);
 
-        let has_time_limit = self.params.max_deterministic_time.is_some()
-            || self.params.max_time_in_seconds.is_some();
-        let has_gap_limit =
-            self.params.relative_gap_limit.is_some() || self.params.absolute_gap_limit.is_some();
+                let has_time_limit = self.solver_params.max_deterministic_time.is_some()
+                    || self.solver_params.max_time_in_seconds.is_some();
+                let has_gap_limit = self.solver_params.relative_gap_limit.is_some()
+                    || self.solver_params.absolute_gap_limit.is_some();
 
-        let status = response.status();
-        let status_from_limits = || {
-            if has_time_limit {
-                SolutionStatus::TimeLimit
-            } else if has_gap_limit {
-                SolutionStatus::GapLimit
-            } else {
-                SolutionStatus::Optimal
-            }
-        };
+                let status = response.status();
+                let status_from_limits = || {
+                    if has_time_limit {
+                        SolutionStatus::TimeLimit
+                    } else if has_gap_limit {
+                        SolutionStatus::GapLimit
+                    } else {
+                        SolutionStatus::Optimal
+                    }
+                };
 
-        match status {
-            CpSolverStatus::Optimal => Ok(CpSatSolution {
-                response,
-                status: SolutionStatus::Optimal,
-                cp_sat_vars: self.cp_sat_vars,
-            }),
-            CpSolverStatus::Feasible => Ok(CpSatSolution {
-                response,
-                status: status_from_limits(),
-                cp_sat_vars: self.cp_sat_vars,
-            }),
-            CpSolverStatus::Infeasible => Err(ResolutionError::Infeasible),
-            CpSolverStatus::Unknown => {
-                if !response.solution.is_empty() {
-                    Ok(CpSatSolution {
+                match status {
+                    CpSolverStatus::Optimal => Ok(CpSatSolution {
+                        response,
+                        status: SolutionStatus::Optimal,
+                        cp_sat_vars,
+                    }),
+                    CpSolverStatus::Feasible => Ok(CpSatSolution {
                         response,
                         status: status_from_limits(),
-                        cp_sat_vars: self.cp_sat_vars,
-                    })
-                } else if has_time_limit {
-                    Err(ResolutionError::Other(
-                        "Time limit reached without finding a feasible solution",
-                    ))
-                } else {
-                    Err(ResolutionError::Other(
-                        "Unknown solver status: search limit reached or other interruption",
-                    ))
+                        cp_sat_vars,
+                    }),
+                    CpSolverStatus::Infeasible => Err(ResolutionError::Infeasible),
+                    CpSolverStatus::Unknown => {
+                        if !response.solution.is_empty() {
+                            Ok(CpSatSolution {
+                                response,
+                                status: status_from_limits(),
+                                cp_sat_vars,
+                            })
+                        } else if has_time_limit {
+                            Err(ResolutionError::Other(
+                                "Time limit reached without finding a feasible solution",
+                            ))
+                        } else {
+                            Err(ResolutionError::Other(
+                                "Unknown solver status: search limit reached or other interruption",
+                            ))
+                        }
+                    }
+                    CpSolverStatus::ModelInvalid => {
+                        let validation = model.validate_cp_model();
+                        Err(ResolutionError::Str(format!(
+                            "Invalid CP-SAT model: {}",
+                            validation
+                        )))
+                    }
                 }
-            }
-            CpSolverStatus::ModelInvalid => {
-                let validation = self.model.validate_cp_model();
-                Err(ResolutionError::Str(format!(
-                    "Invalid CP-SAT model: {}",
-                    validation
-                )))
             }
         }
     }
 
     fn add_constraint(&mut self, constraint: Constraint) -> ConstraintReference {
-        let index = self.model.proto().constraints.len();
+        match &mut self.state {
+            ProblemState::Invalid {
+                next_constraint_index,
+                ..
+            } => {
+                let index = *next_constraint_index;
+                *next_constraint_index += 1;
+                ConstraintReference { index }
+            }
+            ProblemState::Valid {
+                model, cp_sat_vars, ..
+            } => {
+                let index = model.proto().constraints.len();
 
-        // good_lp Constraint:
-        //   expression = sum(coeff_i * var_i) + constant
-        //   is_equality = true  => expression == 0 => sum(coeff_i * var_i) == -constant
-        //   is_equality = false => expression <= 0 => sum(coeff_i * var_i) <= -constant
+                let constant_i64 = match verify_integer(-constraint.expression.constant) {
+                    Ok(val) => val,
+                    Err(e) => {
+                        self.state.into_invalid(e, index + 1);
+                        return ConstraintReference { index };
+                    }
+                };
+                let linear_expr =
+                    match expr_from_constraint_expression(cp_sat_vars, &constraint.expression) {
+                        Ok(expr) => expr,
+                        Err(e) => {
+                            self.state.into_invalid(e, index + 1);
+                            return ConstraintReference { index };
+                        }
+                    };
 
-        let constant_i64 = round_i64(-constraint.expression.constant);
-        let linear_expr = self.expr_from_constraint_expression(&constraint.expression);
+                if constraint.is_equality {
+                    model.add_eq(linear_expr, constant_i64);
+                } else {
+                    model.add_le(linear_expr, constant_i64);
+                }
 
-        if constraint.is_equality {
-            self.model.add_eq(linear_expr, constant_i64);
-        } else {
-            self.model.add_le(linear_expr, constant_i64);
+                ConstraintReference { index }
+            }
         }
-
-        ConstraintReference { index }
     }
 
     fn name() -> &'static str {
@@ -369,36 +482,41 @@ impl WithInitialSolution for CpSatProblem {
         mut self,
         solution: impl IntoIterator<Item = (Variable, f64)>,
     ) -> Self {
-        for (var, val) in solution {
-            let cp_var = self.cp_sat_vars[var.index()];
-            let hint_value = round_i64(val);
-            self.model.add_hint(cp_var, hint_value);
+        match &mut self.state {
+            ProblemState::Invalid { .. } => self,
+            ProblemState::Valid {
+                model, cp_sat_vars, ..
+            } => {
+                for (var, val) in solution {
+                    if !val.is_finite() {
+                        continue;
+                    }
+                    if let Ok(hint_value) = verify_integer(val) {
+                        model.add_hint(cp_sat_vars[var.index()], hint_value);
+                    }
+                }
+                self
+            }
         }
-        self
     }
 }
 
 impl WithTimeLimit for CpSatProblem {
     fn with_time_limit<T: Into<f64>>(mut self, seconds: T) -> Self {
-        self.params.max_time_in_seconds = Some(seconds.into());
+        self.solver_params.max_time_in_seconds = Some(seconds.into());
         self
     }
 }
 
 impl WithMipGap for CpSatProblem {
     fn mip_gap(&self) -> Option<f32> {
-        self.params.relative_gap_limit.map(|v| v as f32)
+        self.solver_params.relative_gap_limit.map(|v| v as f32)
     }
 
     fn with_mip_gap(mut self, mip_gap: f32) -> Result<Self, MipGapError> {
-        if mip_gap.is_sign_negative() {
-            Err(MipGapError::Negative)
-        } else if mip_gap.is_infinite() {
-            Err(MipGapError::Infinite)
-        } else {
-            self.params.relative_gap_limit = Some(mip_gap as f64);
-            Ok(self)
-        }
+        validate_gap(mip_gap as f64)?;
+        self.solver_params.relative_gap_limit = Some(mip_gap as f64);
+        Ok(self)
     }
 }
 
@@ -614,12 +732,198 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "does not support continuous variables")]
-    fn test_continuous_var_panics() {
+    fn test_non_integer_coefficient_in_objective_returns_error() {
         let mut vars = variables!();
-        let _x = vars.add(variable().min(0).max(10)); // not integer
-        let pb = vars.maximise(_x).using(cp_sat);
-        let _ = pb.solve();
+        let x = vars.add(variable().integer().min(0).max(10));
+        let pb = vars.maximise(2.5 * x).using(cp_sat);
+        let result = pb.solve();
+        assert!(result.is_err());
+        let err = result.err().unwrap();
+        match &err {
+            crate::ResolutionError::Str(msg) => {
+                assert!(
+                    msg.contains("not an integer"),
+                    "Error message should mention non-integer, got: {msg}"
+                );
+            }
+            other => panic!("Expected ResolutionError::Str, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_non_integer_coefficient_in_constraint_returns_error() {
+        let mut vars = variables!();
+        let x = vars.add(variable().integer().min(0).max(10));
+        let pb = vars
+            .maximise(x)
+            .using(cp_sat)
+            .with(constraint!(2.5 * x <= 10));
+        let result = pb.solve();
+        assert!(result.is_err());
+        let err = result.err().unwrap();
+        match &err {
+            crate::ResolutionError::Str(msg) => {
+                assert!(
+                    msg.contains("not an integer"),
+                    "Error message should mention non-integer, got: {msg}"
+                );
+            }
+            other => panic!("Expected ResolutionError::Str, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_non_integer_constant_in_constraint_returns_error() {
+        let mut vars = variables!();
+        let x = vars.add(variable().integer().min(0).max(10));
+        let pb = vars.maximise(x).using(cp_sat).with(constraint!(x <= 10.5));
+        let result = pb.solve();
+        assert!(result.is_err());
+        let err = result.err().unwrap();
+        match &err {
+            crate::ResolutionError::Str(msg) => {
+                assert!(
+                    msg.contains("not an integer"),
+                    "Error message should mention non-integer, got: {msg}"
+                );
+            }
+            other => panic!("Expected ResolutionError::Str, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_non_integer_initial_solution_is_skipped() {
+        let mut vars = variables!();
+        let x = vars.add(variable().integer().min(0).max(10));
+        let pb = vars
+            .maximise(x)
+            .using(cp_sat)
+            .with_initial_solution(vec![(x, 2.5)]);
+        let sol = pb.solve().unwrap();
+        // Non-integer hint is skipped, solve proceeds normally
+        assert_eq!(sol.value(x), 10.0);
+    }
+
+    #[test]
+    fn test_continuous_var_returns_error() {
+        let mut vars = variables!();
+        let x = vars.add(variable().min(0).max(10)); // not integer
+        let pb = vars.maximise(x).using(cp_sat);
+        let result = pb.solve();
+        assert!(result.is_err());
+        let err = result.err().unwrap();
+        match &err {
+            crate::ResolutionError::Str(msg) => {
+                assert!(
+                    msg.contains("does not support continuous variables"),
+                    "Error message should mention continuous variables, got: {msg}"
+                );
+            }
+            other => panic!("Expected ResolutionError::Str, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_invalid_bounds_returns_error() {
+        let mut vars = variables!();
+        let x = vars.add(variable().integer().min(10).max(0)); // lower > upper
+        let pb = vars.maximise(x).using(cp_sat);
+        let result = pb.solve();
+        assert!(result.is_err());
+        let err = result.err().unwrap();
+        match &err {
+            crate::ResolutionError::Str(msg) => {
+                assert!(
+                    msg.contains("Invalid bounds"),
+                    "Error message should mention invalid bounds, got: {msg}"
+                );
+            }
+            other => panic!("Expected ResolutionError::Str, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_non_integer_bound_returns_error() {
+        let mut vars = variables!();
+        let x = vars.add(variable().integer().min(2.5).max(10)); // non-integer lower bound
+        let pb = vars.maximise(x).using(cp_sat);
+        let result = pb.solve();
+        assert!(result.is_err());
+        let err = result.err().unwrap();
+        match &err {
+            crate::ResolutionError::Str(msg) => {
+                assert!(
+                    msg.contains("not an integer"),
+                    "Error message should mention non-integer, got: {msg}"
+                );
+            }
+            other => panic!("Expected ResolutionError::Str, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_infinite_bound_returns_error() {
+        let mut vars = variables!();
+        let x = vars.add(variable().integer().min(f64::NEG_INFINITY).max(10)); // infinite lower bound
+        let pb = vars.maximise(x).using(cp_sat);
+        let result = pb.solve();
+        assert!(result.is_err());
+        let err = result.err().unwrap();
+        match &err {
+            crate::ResolutionError::Str(msg) => {
+                assert!(
+                    msg.contains("does not accept infinite values"),
+                    "Error message should mention infinite values, got: {msg}"
+                );
+            }
+            other => panic!("Expected ResolutionError::Str, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_nan_coefficient_in_constraint_returns_error() {
+        let mut vars = variables!();
+        let x = vars.add(variable().integer().min(0).max(10));
+        let pb = vars
+            .maximise(x)
+            .using(cp_sat)
+            .with(constraint!(x <= f64::NAN));
+        let result = pb.solve();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_nan_in_initial_solution_is_skipped() {
+        let mut vars = variables!();
+        let x = vars.add(variable().integer().min(0).max(10));
+        let pb = vars
+            .maximise(x)
+            .using(cp_sat)
+            .with_initial_solution(vec![(x, f64::NAN)]);
+        let sol = pb.solve().unwrap();
+        assert_eq!(sol.value(x), 10.0);
+    }
+
+    #[test]
+    fn test_continuous_var_in_multi_var_problem() {
+        // Only the first variable is invalid — the whole problem should still error
+        let mut vars = variables!();
+        let x = vars.add(variable().min(0).max(10)); // not integer
+        let y = vars.add(variable().integer().min(0).max(5));
+        let pb = vars.maximise(x + y).using(cp_sat);
+        let result = pb.solve();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_as_inner_on_invalid() {
+        let mut vars = variables!();
+        let x = vars.add(variable().min(0).max(10)); // not integer
+        let pb = vars.maximise(x).using(cp_sat);
+        // as_inner returns None in invalid state
+        assert!(pb.as_inner().is_none());
+        // But params are still accessible
+        assert!(pb.params().num_search_workers.is_none());
     }
 
     #[test]
@@ -659,11 +963,10 @@ mod tests {
 
         let sol = pb.solve().unwrap();
         assert_eq!(sol.status(), SolutionStatus::Optimal);
-        // solution_log name is included in the response
         assert!(
             sol.solution_log().contains("OPTIMAL")
                 || sol.solution_log().contains("objective")
-                || sol.solution_log().is_empty(), // CP-SAT may not populate solve_log
+                || sol.solution_log().is_empty(),
         );
     }
 
@@ -723,6 +1026,7 @@ mod tests {
 
     #[test]
     fn solve_with_mip_abs_gap_negative_errors() {
+        // Uses no variables, so params are always accessible
         let pb = cp_sat(variables!().maximise(0));
         let result = pb.set_mip_abs_gap(-1.0);
         assert!(result.is_err());
@@ -744,9 +1048,7 @@ mod tests {
 
         let sol = pb.solve().unwrap();
         let stats = sol.response_stats();
-        // The stats string should be non-empty and contain status information
         assert!(!stats.is_empty());
-        // It should mention OPTIMAL since we got an optimal solution
         assert!(
             stats.contains("OPTIMAL") || stats.contains("optimal"),
             "response_stats should mention OPTIMAL, got: {stats}"
@@ -761,10 +1063,21 @@ mod tests {
         let pb = vars.maximise(x).using(cp_sat);
 
         let stats = pb.model_stats();
+        assert!(stats.is_some(), "model_stats should be Some, got: None");
         assert!(
-            !stats.is_empty(),
-            "model_stats should not be empty, got: {stats}"
+            !stats.as_ref().unwrap().is_empty(),
+            "model_stats should not be empty, got: {:?}",
+            stats
         );
+    }
+
+    #[test]
+    fn test_model_stats_on_invalid() {
+        let mut vars = variables!();
+        let x = vars.add(variable().min(0).max(10)); // not integer
+        let pb = vars.maximise(x).using(cp_sat);
+        // model_stats returns None in invalid state
+        assert!(pb.model_stats().is_none());
     }
 
     #[test]
@@ -778,7 +1091,6 @@ mod tests {
             .set_num_search_workers(4)
             .set_random_seed(99);
 
-        // Check that params are accessible
         assert_eq!(pb.params().num_search_workers, Some(4));
         assert_eq!(pb.params().random_seed, Some(99));
 
@@ -795,7 +1107,6 @@ mod tests {
 
         let pb = vars.maximise(x).using(cp_sat).with_mip_gap(0.05).unwrap();
 
-        // The mip_gap should be accessible
         assert_eq!(pb.mip_gap(), Some(0.05));
 
         let sol = pb.solve().unwrap();
@@ -819,7 +1130,6 @@ mod tests {
         let mut vars = variables!();
         let x = vars.add(variable().binary());
 
-        // Use params_mut to set time limit directly
         let mut pb = vars.maximise(x).using(cp_sat);
         pb.params_mut().max_deterministic_time = Some(10.0);
 
@@ -829,7 +1139,6 @@ mod tests {
 
     #[test]
     fn solve_with_verbose_and_response_log() {
-        // Test that both verbose and log_to_response can be combined
         let mut vars = variables!();
         let x = vars.add(variable().integer().min(0).max(10));
 

--- a/src/solvers/mod.rs
+++ b/src/solvers/mod.rs
@@ -41,6 +41,10 @@ pub mod lp_solvers;
 #[cfg_attr(docsrs, doc(cfg(feature = "clarabel")))]
 pub mod clarabel;
 
+#[cfg(feature = "cp_sat")]
+#[cfg_attr(docsrs, doc(cfg(feature = "cp_sat")))]
+pub mod cp_sat;
+
 /// An entity that is able to solve linear problems
 pub trait Solver {
     /// The internal model type used by the solver
@@ -253,7 +257,7 @@ pub trait WithTimeLimit {
 
 /// Information about the status of a solution, such as whether the solution is
 /// optimal
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum SolutionStatus {
     /// The solution is optimal
     Optimal,


### PR DESCRIPTION
This PR adds a bridge to the **Google OR-Tools CP-SAT solver** via the [`cp_sat`](https://crates.io/crates/cp_sat) Rust crate (v0.4.0), accessible through the `cp_sat` feature flag.

CP-SAT is one of the fastest open-source solvers for combinatorial (integer) optimization problems. It supports integer and boolean variables, linear objectives, linear constraints, and advanced features like solution hints (warm-starting), time limits, MIP gaps, parallel search with different search strategies, and verbose logging.

## Implementation

The bridge lives in `src/solvers/cp_sat.rs` and covers:

- **`cp_sat()` function**: Converts `UnsolvedProblem` to `CpSatProblem`
- **`SolverModel` impl**: `add_constraint()` with equality/inequality support, `solve()` with full status mapping
- **`WithInitialSolution` impl**: Warm-start hints via `CpModelBuilder::add_hint()`
- **`WithTimeLimit` impl**: Set `max_time_in_seconds` on internal parameters
- **`WithMipGap` impl**: Set `relative_gap_limit` on internal parameters
- **Additional API**: configuring verbosity and some search parameters (`set_verbose()`, `set_log_to_response()`, `set_num_search_workers()`, `set_random_seed()`, ...)
- **`CpSatSolution`** wraps `CpSolverResponse` with access to `response_stats()`, `solution_log()`, `additional_solutions()`, `into_response()`
- **24 unit tests** covering core functionality, edge cases, and error handling (all passing)

## Limitations & Rough Edges

Unlike most other good_lp solvers, the `cp_sat` crate links dynamically to a very heavy OR-Tools shared library. This is handled by the cp_sat crate but it does so a little clumsily, relying on correct setting of environment variables (Note I am already working on a better ortools to rust interface, which could replace this crate in the future). Currently, users must:
   - Install OR-Tools on their system (prebuilt binaries provided for different Linux distribution, macos and WIndows via Github releases)
   - Set `ORTOOLS_PREFIX`, `RUSTFLAGS="-L /opt/ortools/lib -lprotobuf"`, `LD_LIBRARY_PATH=/opt/ortools/lib`

As the OR-Tools prebuilt binary is platform-specific, I currently pin it to `ubuntu-24.04` in CI. The CI job runs only cp_sat-specific lib tests (`cargo test --lib -- cp_sat`), not integration tests which use continuous variables and would panic.

For now I did not put it into `all_default_solvers` due to the heavy external dependency (OR-Tools shared libraries), cp_sat is opt-in only, similar to `cplex-rs`.

## Progress on Fixes

- [x] No more rounding. Reject non-integer values instead (turns model invalid, clean error is returned during `solve()`.
- [x] Don't special-case CI workflow
- [x] Replace lambda with imperative logic
- [x] Don't require manual env vars
- [x] Point to upstream OR-Tools install docs
- [x] Remove redundant `dep:cp_sat`
- [x] Remove duplicate solver list in `src/lib.rs`