### PR TITLE
Update highs dependency version to 2.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ minilp = [
 coin_cbc = { version = "0.1", optional = true, default-features = false }
 microlp = { version = "0.4.0", optional = true }
 lpsolve = { version = "1.0.1", optional = true }
-highs = { version = "2.0.0", optional = true }
+highs = { version = "2.2.0", optional = true }
 russcip = { version = "0.9.1", optional = true }
 lp-solvers = { version = "1.0.0", features = ["cplex"], optional = true }
 cplex-rs = { version = "0.1.9", optional = true }


### PR DESCRIPTION
This should fix #127 (crate does not build with minimum version). I think this is really the fault of highs not following semver correctly.

Can we get this propagated to crates.io so I can update my project? Thanks