### PR TITLE
docs: document CBC solver output behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,11 +101,12 @@ Note that the `lpsolve` and `cplex-rs` features are mutually exclusive, and they
 Used by default, performant, but requires to have the cbc C library headers available on the build machine,
 and the cbc dynamic library available on any machine where you want to run your program.
 
-CBC may write solver progress messages to the process's standard output while solving.
-The current `good_lp` API does not provide a solver-independent way to suppress output
-from CBC. If silent solver output is a requirement for your application, consider
-selecting another solver from the table above and verify its output behavior for your
-deployment. This limitation is tracked in [issue #117](https://github.com/rust-or/good_lp/issues/117).
+> **Note:** CBC itself does not provide a way to fully suppress its solver
+> progress output — this is a limitation of the underlying CBC library,
+> not of `good_lp`'s API. If silent solver output is a requirement for your
+> application, consider selecting another solver from the table above and
+> verify its output behavior for your deployment. This limitation is
+> tracked in [issue #117](https://github.com/rust-or/good_lp/issues/117).
 
 In ubuntu, you can install it with:
 

--- a/README.md
+++ b/README.md
@@ -101,12 +101,19 @@ Note that the `lpsolve` and `cplex-rs` features are mutually exclusive, and they
 Used by default, performant, but requires to have the cbc C library headers available on the build machine,
 and the cbc dynamic library available on any machine where you want to run your program.
 
-> **Note:** CBC itself does not provide a way to fully suppress its solver
-> progress output — this is a limitation of the underlying CBC library,
-> not of `good_lp`'s API. If silent solver output is a requirement for your
-> application, consider selecting another solver from the table above and
-> verify its output behavior for your deployment. This limitation is
-> tracked in [issue #117](https://github.com/rust-or/good_lp/issues/117).
+> **Note:** CBC can write solver progress output while solving. The
+> `coin_cbc` integration exposes CBC's parameter API, so setting `log` to `0`
+> can suppress much of that output:
+>
+> ```rust
+> let mut model = vars.maximise(objective).using(coin_cbc);
+> model.set_parameter("log", "0");
+> ```
+>
+> This does not guarantee completely silent output for every CBC/CLP version.
+> If silent solver output is a requirement for your application, consider
+> selecting another solver from the table above and verify its output behavior
+> for your deployment. This limitation is tracked in [issue #117](https://github.com/rust-or/good_lp/issues/117).
 
 In ubuntu, you can install it with:
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,12 @@ Note that the `lpsolve` and `cplex-rs` features are mutually exclusive, and they
 Used by default, performant, but requires to have the cbc C library headers available on the build machine,
 and the cbc dynamic library available on any machine where you want to run your program.
 
+CBC may write solver progress messages to the process's standard output while solving.
+The current `good_lp` API does not provide a solver-independent way to suppress output
+from CBC. If silent solver output is a requirement for your application, consider
+selecting another solver from the table above and verify its output behavior for your
+deployment. This limitation is tracked in [issue #117](https://github.com/rust-or/good_lp/issues/117).
+
 In ubuntu, you can install it with:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ and the cbc dynamic library available on any machine where you want to run your 
 > can suppress much of that output:
 >
 > ```rust
-> let mut model = vars.maximise(objective).using(coin_cbc);
+> let mut model = vars.maximise(objective).using(good_lp::coin_cbc);
 > model.set_parameter("log", "0");
 > ```
 >

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Used by default, performant, but requires to have the cbc C library headers avai
 and the cbc dynamic library available on any machine where you want to run your program.
 
 > **Note:** CBC itself does not provide a way to fully suppress its solver
-> progress output — this is a limitation of the underlying CBC library,
+> progress output; this is a limitation of the underlying CBC library,
 > not of `good_lp`'s API. If silent solver output is a requirement for your
 > application, consider selecting another solver from the table above and
 > verify its output behavior for your deployment. This limitation is


### PR DESCRIPTION
## Summary

This documentation-only change explains an important behavior of the default CBC solver: it may write solver progress messages to the process's standard output while a model is being solved.

It documents the solver-specific control already exposed by the `coin_cbc` integration: `model.set_parameter("log", "0")` suppresses much of CBC's progress output, but does not guarantee completely silent output across CBC/CLP versions. It also clarifies that `good_lp` does not currently provide a solver-independent output-suppression switch. Users whose applications require fully silent solver output are directed to consider another solver and to verify that solver's behavior for their deployment.

The note is placed in the CBC section of the solver documentation, where users are already evaluating solver-specific trade-offs, and links to issue #117 for context.

## Why

Issue #117 reports unexpected solver output when solving multiple problems. The existing documentation describes CBC's installation requirements and performance characteristics, but does not mention its output behavior or the available CBC-specific parameter. Documenting both prevents users from discovering the limitation only after integrating the default solver into an application.

## Scope

- Documentation only; no solver behavior or public API is changed.
- No claim is made that issue #117 is fixed at the implementation level.
- The wording distinguishes CBC-specific configuration from the absence of a solver-independent API.

## Validation

- `cargo fmt -- --check`
- `git diff --check`
- Reproduced the behavior with the repository's `coin_cbc` 0.1.8 integration and CBC 2.10.12 under WSL2 Ubuntu: `log=0` removed the main progress output while `Presolve` and `Optimal objective` summary lines remained on stdout.