### PR TITLE
fix: correct dual signs for >= constraints

### DIFF
--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -9,17 +9,40 @@ use std::ops::{Shl, Shr, Sub};
 pub struct Constraint {
     /// The expression that is constrained to be null or negative
     pub(crate) expression: Expression,
-    /// if is_equality, represents expression == 0, otherwise, expression <= 0
-    pub(crate) is_equality: bool,
+    /// The direction of the constraint before it is normalized for a solver.
+    pub(crate) direction: ConstraintDirection,
     /// Optional constraint name
     pub(crate) name: Option<String>,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ConstraintDirection {
+    LessOrEqual,
+    Equal,
+    GreaterOrEqual,
+}
+
+impl ConstraintDirection {
+    fn is_equality(self) -> bool {
+        matches!(self, Self::Equal)
+    }
+
+    #[cfg(any(feature = "highs", feature = "clarabel"))]
+    fn dual_sign(self) -> f64 {
+        // `>=` constraints are normalized by reversing the expression and its RHS.
+        if matches!(self, Self::GreaterOrEqual) {
+            -1.
+        } else {
+            1.
+        }
+    }
+}
+
 impl Constraint {
-    fn new(expression: Expression, is_equality: bool) -> Constraint {
+    fn new(expression: Expression, direction: ConstraintDirection) -> Constraint {
         Constraint {
             expression,
-            is_equality,
+            direction,
             name: None,
         }
     }
@@ -35,9 +58,13 @@ impl Constraint {
         &self.expression
     }
 
-    /// if is_equality, represents expression == 0, otherwise, expression <= 0
+    /// Returns whether this constraint is an equality.
     pub fn is_equality(&self) -> bool {
-        self.is_equality
+        self.direction.is_equality()
+    }
+
+    pub(crate) fn reference(&self, index: usize) -> ConstraintReference {
+        ConstraintReference::with_direction(index, self.direction)
     }
 
     /// get the constraint name, if it exists.
@@ -52,7 +79,15 @@ impl FormatWithVars for Constraint {
         FUN: FnMut(&mut Formatter<'_>, Variable) -> std::fmt::Result,
     {
         self.expression.linear.format_with(f, variable_format)?;
-        write!(f, " {} ", if self.is_equality { "=" } else { "<=" })?;
+        write!(
+            f,
+            " {} ",
+            if self.direction.is_equality() {
+                "="
+            } else {
+                "<="
+            }
+        )?;
         write!(f, "{}", -self.expression.constant)
     }
 }
@@ -65,17 +100,18 @@ impl Debug for Constraint {
 
 /// equals
 pub fn eq<B, A: Sub<B, Output = Expression>>(a: A, b: B) -> Constraint {
-    Constraint::new(a - b, true)
+    Constraint::new(a - b, ConstraintDirection::Equal)
 }
 
 /// less than or equal
 pub fn leq<B, A: Sub<B, Output = Expression>>(a: A, b: B) -> Constraint {
-    Constraint::new(a - b, false)
+    Constraint::new(a - b, ConstraintDirection::LessOrEqual)
 }
 
 /// greater than or equal
 pub fn geq<A, B: Sub<A, Output = Expression>>(a: A, b: B) -> Constraint {
-    leq(b, a)
+    // Keep the original direction so dual values can be mapped back after normalization.
+    Constraint::new(b - a, ConstraintDirection::GreaterOrEqual)
 }
 
 macro_rules! impl_shifts {
@@ -158,10 +194,38 @@ macro_rules! constraint {
     };
 }
 
-#[derive(Clone, PartialEq, Debug)]
-/// A constraint reference contains the sequence id of the constraint within the problem
+#[derive(Clone)]
+/// A constraint reference contains the sequence id and direction of a constraint within the problem.
 pub struct ConstraintReference {
     pub(crate) index: usize,
+    // This metadata is consumed by the dual-capable solver integrations.
+    #[allow(dead_code)]
+    direction: ConstraintDirection,
+}
+
+impl ConstraintReference {
+    pub(crate) fn with_direction(index: usize, direction: ConstraintDirection) -> Self {
+        Self { index, direction }
+    }
+
+    #[cfg(any(feature = "highs", feature = "clarabel"))]
+    pub(crate) fn dual_sign(&self) -> f64 {
+        self.direction.dual_sign()
+    }
+}
+
+impl PartialEq for ConstraintReference {
+    fn eq(&self, other: &Self) -> bool {
+        self.index == other.index
+    }
+}
+
+impl Debug for ConstraintReference {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ConstraintReference")
+            .field("index", &self.index)
+            .finish()
+    }
 }
 
 #[cfg(test)]

--- a/src/solvers/clarabel.rs
+++ b/src/solvers/clarabel.rs
@@ -38,6 +38,7 @@ pub fn clarabel(to_solve: UnsolvedProblem) -> ClarabelProblem {
     settings.verbose(false).tol_feas(1e-9);
     let mut p = ClarabelProblem {
         objective: objective_vector,
+        objective_direction: direction,
         constraints_matrix_builder,
         constraint_values: Vec::new(),
         variables: variables.len(),
@@ -64,6 +65,7 @@ pub struct ClarabelProblem {
     constraints_matrix_builder: CscMatrixBuilder,
     constraint_values: Vec<f64>,
     objective: Vec<f64>,
+    objective_direction: ObjectiveDirection,
     variables: usize,
     settings: DefaultSettingsBuilder<f64>,
     cones: Vec<SupportedConeT<f64>>,
@@ -112,6 +114,7 @@ impl SolverModel for ClarabelProblem {
     type Error = ResolutionError;
 
     fn solve(self) -> Result<Self::Solution, Self::Error> {
+        let objective_direction = self.objective_direction;
         let mut solver = self.try_into_solver()?;
         solver.solve();
         match solver.solution.status {
@@ -123,6 +126,7 @@ impl SolverModel for ClarabelProblem {
             | SolverStatus::AlmostDualInfeasible
             | SolverStatus::DualInfeasible => Ok(ClarabelSolution {
                 solution: solver.solution,
+                objective_direction,
             }),
             SolverStatus::Unsolved => Err(ResolutionError::Other("Unsolved")),
             SolverStatus::MaxIterations => Err(ResolutionError::Other("Max iterations reached")),
@@ -163,6 +167,7 @@ impl SolverModel for ClarabelProblem {
 /// The solution to a clarabel problem
 pub struct ClarabelSolution {
     solution: DefaultSolution<f64>,
+    objective_direction: ObjectiveDirection,
 }
 
 impl ClarabelSolution {
@@ -196,7 +201,14 @@ impl<'a> SolutionWithDual<'a> for ClarabelSolution {
 
 impl DualValues for &ClarabelSolution {
     fn dual(&self, constraint: ConstraintReference) -> f64 {
-        self.solution.z[constraint.index] * constraint.dual_sign()
+        // The objective is negated for maximization, so only that path needs
+        // the constraint-direction correction for Clarabel's dual convention.
+        let sign = if self.objective_direction == ObjectiveDirection::Maximisation {
+            constraint.dual_sign()
+        } else {
+            1.
+        };
+        self.solution.z[constraint.index] * sign
     }
 }
 

--- a/src/solvers/clarabel.rs
+++ b/src/solvers/clarabel.rs
@@ -134,13 +134,14 @@ impl SolverModel for ClarabelProblem {
     }
 
     fn add_constraint(&mut self, constraint: Constraint) -> ConstraintReference {
+        let reference = constraint.reference(self.constraint_values.len());
+        let is_equality = constraint.is_equality();
         self.constraints_matrix_builder
             .add_row(constraint.expression.linear);
-        let index = self.constraint_values.len();
         self.constraint_values.push(-constraint.expression.constant);
         // Cones indicate the type of constraint. We only support nonnegative and equality constraints.
         // To avoid creating a new cone for each constraint, we merge them.
-        let next_cone = if constraint.is_equality {
+        let next_cone = if is_equality {
             ZeroConeT(1)
         } else {
             NonnegativeConeT(1)
@@ -151,7 +152,7 @@ impl SolverModel for ClarabelProblem {
             (Some(NonnegativeConeT(a)), NonnegativeConeT(b)) => *a += b,
             (_, next_cone) => self.cones.push(next_cone),
         };
-        ConstraintReference { index }
+        reference
     }
 
     fn name() -> &'static str {
@@ -195,7 +196,7 @@ impl<'a> SolutionWithDual<'a> for ClarabelSolution {
 
 impl DualValues for &ClarabelSolution {
     fn dual(&self, constraint: ConstraintReference) -> f64 {
-        self.solution.z[constraint.index]
+        self.solution.z[constraint.index] * constraint.dual_sign()
     }
 }
 

--- a/src/solvers/coin_cbc.rs
+++ b/src/solvers/coin_cbc.rs
@@ -174,9 +174,10 @@ impl SolverModel for CoinCbcProblem {
 
     fn add_constraint(&mut self, constraint: Constraint) -> ConstraintReference {
         let index = self.model.num_rows().try_into().unwrap();
+        let reference = constraint.reference(index);
         let row = self.model.add_row();
         let constant = -constraint.expression.constant;
-        if constraint.is_equality {
+        if constraint.is_equality() {
             self.model.set_row_equal(row, constant);
         } else {
             self.model.set_row_upper(row, constant);
@@ -184,7 +185,7 @@ impl SolverModel for CoinCbcProblem {
         for (var, coeff) in constraint.expression.linear.coefficients.into_iter() {
             self.model.set_weight(row, self.columns[var.index()], coeff);
         }
-        ConstraintReference { index }
+        reference
     }
 
     fn name() -> &'static str {

--- a/src/solvers/cplex.rs
+++ b/src/solvers/cplex.rs
@@ -129,6 +129,7 @@ impl SolverModel for CPLEXProblem {
     }
 
     fn add_constraint(&mut self, c: Constraint) -> ConstraintReference {
+        let direction = c.direction;
         let rhs = -c.expression.constant;
         let weighted_variables = c
             .expression
@@ -137,7 +138,7 @@ impl SolverModel for CPLEXProblem {
             .iter()
             .map(|(var, &coeff)| (self.id_for_var[var], coeff))
             .collect::<Vec<_>>();
-        let con_type = if c.is_equality {
+        let con_type = if c.is_equality() {
             ConstraintType::Eq
         } else {
             ConstraintType::LessThanEq
@@ -149,9 +150,7 @@ impl SolverModel for CPLEXProblem {
             .add_constraint(cplex_con)
             .expect("Unable to add constraint to cplex model, aborting");
 
-        ConstraintReference {
-            index: con_index.into_inner(),
-        }
+        ConstraintReference::with_direction(con_index.into_inner(), direction)
     }
 
     fn name() -> &'static str {

--- a/src/solvers/highs.rs
+++ b/src/solvers/highs.rs
@@ -350,19 +350,21 @@ impl SolverModel for HighsProblem {
 
     fn add_constraint(&mut self, constraint: Constraint) -> ConstraintReference {
         let index = self.highs_problem.num_rows();
+        let reference = constraint.reference(index);
+        let is_equality = constraint.is_equality();
         let upper_bound = -constraint.expression.constant();
         let columns = &self.columns;
         let factors = constraint
             .expression
             .linear_coefficients()
             .map(|(variable, factor)| (columns[variable.index()], factor));
-        if constraint.is_equality {
+        if is_equality {
             self.highs_problem
                 .add_row(upper_bound..=upper_bound, factors);
         } else {
             self.highs_problem.add_row(..=upper_bound, factors);
         }
-        ConstraintReference { index }
+        reference
     }
 
     fn name() -> &'static str {
@@ -411,7 +413,7 @@ impl Solution for HighsSolution {
 
 impl DualValues for &HighsSolution {
     fn dual(&self, constraint: ConstraintReference) -> f64 {
-        self.solution.dual_rows()[constraint.index]
+        self.solution.dual_rows()[constraint.index] * constraint.dual_sign()
     }
 }
 

--- a/src/solvers/lp_solvers.rs
+++ b/src/solvers/lp_solvers.rs
@@ -114,14 +114,12 @@ impl<T: SolverTrait> SolverModel for Model<T> {
     }
 
     fn add_constraint(&mut self, c: Constraint) -> ConstraintReference {
-        let reference = ConstraintReference {
-            index: self.problem.constraints.len(),
-        };
+        let reference = c.reference(self.problem.constraints.len());
         self.problem
             .constraints
             .push(lp_solvers::lp_format::Constraint {
                 lhs: linear_coefficients_str(&c.expression, &self.problem.variables),
-                operator: if c.is_equality {
+                operator: if c.is_equality() {
                     Ordering::Equal
                 } else {
                     Ordering::Less

--- a/src/solvers/lpsolve.rs
+++ b/src/solvers/lpsolve.rs
@@ -107,12 +107,14 @@ impl SolverModel for LpSolveProblem {
 
     fn add_constraint(&mut self, constraint: Constraint) -> ConstraintReference {
         let index = self.0.num_rows().try_into().expect("too many rows");
+        let reference = constraint.reference(index);
+        let is_equality = constraint.is_equality();
         let mut coeffs: Vec<f64> = vec![0.; self.0.num_cols() as usize + 1];
         let target = -constraint.expression.constant;
         for (var, coeff) in constraint.expression.linear_coefficients() {
             coeffs[var.index() + 1] = coeff;
         }
-        let constraint_type = if constraint.is_equality {
+        let constraint_type = if is_equality {
             ConstraintType::Eq
         } else {
             ConstraintType::Le
@@ -121,7 +123,7 @@ impl SolverModel for LpSolveProblem {
             .0
             .add_constraint(coeffs.as_mut_slice(), target, constraint_type);
         assert!(success.is_ok(), "could not add constraint. memory error.");
-        ConstraintReference { index }
+        reference
     }
 
     fn name() -> &'static str {

--- a/src/solvers/microlp.rs
+++ b/src/solvers/microlp.rs
@@ -153,7 +153,8 @@ impl SolverModel for MicroLpProblem {
 
     fn add_constraint(&mut self, constraint: Constraint) -> ConstraintReference {
         let index = self.n_constraints;
-        let op = match constraint.is_equality {
+        let reference = constraint.reference(index);
+        let op = match constraint.is_equality() {
             true => microlp::ComparisonOp::Eq,
             false => microlp::ComparisonOp::Le,
         };
@@ -164,7 +165,7 @@ impl SolverModel for MicroLpProblem {
         }
         self.problem.add_constraint(linear_expr, op, constant);
         self.n_constraints += 1;
-        ConstraintReference { index }
+        reference
     }
 
     fn name() -> &'static str {

--- a/src/solvers/scip.rs
+++ b/src/solvers/scip.rs
@@ -16,7 +16,7 @@ use russcip::variable::VarType;
 use crate::variable::{UnsolvedProblem, VariableDefinition};
 use crate::{
     CardinalityConstraintSolver, WithInitialSolution, WithMipGap, WithTimeLimit,
-    constraint::ConstraintReference,
+    constraint::{ConstraintDirection, ConstraintReference},
     solvers::{
         MipGapError, ObjectiveDirection, ResolutionError, Solution, SolutionStatus, SolverModel,
     },
@@ -279,7 +279,7 @@ impl CardinalityConstraintSolver for SCIPProblem {
         let scip_vars: Vec<&russcip::Variable> = vars.iter().map(|v| &id_for_var[v]).collect();
         let index = model.n_conss() + 1;
         model.add_cons_cardinality(scip_vars, rhs, format!("cardinality{}", index).as_str());
-        ConstraintReference { index }
+        ConstraintReference::with_direction(index, ConstraintDirection::LessOrEqual)
     }
 }
 
@@ -316,8 +316,10 @@ impl SolverModel for SCIPProblem {
     }
 
     fn add_constraint(&mut self, c: Constraint) -> ConstraintReference {
+        let reference_index = self.model.n_conss() + 1;
+        let reference = c.reference(reference_index);
         let constant = -c.expression.constant;
-        let lhs = match c.is_equality {
+        let lhs = match c.is_equality() {
             true => constant,
             false => -f64::INFINITY,
         };
@@ -331,16 +333,15 @@ impl SolverModel for SCIPProblem {
             coeffs.push(coeff);
         }
 
-        let index = self.model.n_conss() + 1;
         self.model.add_cons(
             vars_in_cons,
             &coeffs,
             lhs,
             constant,
-            format!("c{}", index).as_str(),
+            format!("c{}", reference_index).as_str(),
         );
 
-        ConstraintReference { index }
+        reference
     }
 
     fn name() -> &'static str {

--- a/tests/shadow_price.rs
+++ b/tests/shadow_price.rs
@@ -96,6 +96,28 @@ where
     assert_float_eq!(-2.0, dual.dual(lower_bound), abs <= 1e-6);
 }
 
+#[allow(dead_code)]
+fn greater_than_or_equal_constraint_minimisation_for_solver<S: Solver>(solver: S)
+where
+    for<'a> <<S as Solver>::Model as SolverModel>::Solution: SolutionWithDual<'a>,
+{
+    let mut vars = variables!();
+    let x = vars.add(variable().min(0));
+
+    let objective = 2 * x;
+    let mut problem = vars.minimise(objective.clone()).using(solver);
+    let lower_bound = problem.add_constraint(constraint!(x >= 1));
+
+    let mut solution = problem.solve().expect("Library test");
+
+    assert_float_eq!(1.0, solution.value(x), abs <= 1e-6);
+    assert_float_eq!(2.0, solution.eval(&objective), abs <= 1e-6);
+
+    let dual = solution.compute_dual();
+    // Increasing the lower bound by one increases the minimized objective by two.
+    assert_float_eq!(2.0, dual.dual(lower_bound), abs <= 1e-6);
+}
+
 macro_rules! dual_test {
     ($([$solver_feature:literal, $solver:expr])*) => {
         #[test]
@@ -122,6 +144,15 @@ macro_rules! dual_test {
             $(
                 #[cfg(feature = $solver_feature)]
                 greater_than_or_equal_constraint_for_solver($solver);
+            )*
+        }
+
+        #[test]
+        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+        fn greater_than_or_equal_constraint_minimisation() {
+            $(
+                #[cfg(feature = $solver_feature)]
+                greater_than_or_equal_constraint_minimisation_for_solver($solver);
             )*
         }
     };

--- a/tests/shadow_price.rs
+++ b/tests/shadow_price.rs
@@ -73,6 +73,29 @@ where
     assert_float_eq!(5.0, dual.dual(c2), abs <= 1e-1);
 }
 
+#[allow(dead_code)]
+fn greater_than_or_equal_constraint_for_solver<S: Solver>(solver: S)
+where
+    for<'a> <<S as Solver>::Model as SolverModel>::Solution: SolutionWithDual<'a>,
+{
+    let mut vars = variables!();
+    let x = vars.add(variable().min(0));
+
+    let objective = -2 * x;
+    let mut problem = vars.maximise(objective.clone()).using(solver);
+    let lower_bound = problem.add_constraint(constraint!(x >= 1));
+
+    let mut solution = problem.solve().expect("Library test");
+
+    assert_float_eq!(1.0, solution.value(x), abs <= 1e-6);
+    assert_float_eq!(-2.0, solution.eval(&objective), abs <= 1e-6);
+
+    let dual = solution.compute_dual();
+    // Increasing the lower bound by one forces x up by one and decreases the
+    // maximized objective by two.
+    assert_float_eq!(-2.0, dual.dual(lower_bound), abs <= 1e-6);
+}
+
 macro_rules! dual_test {
     ($([$solver_feature:literal, $solver:expr])*) => {
         #[test]
@@ -90,6 +113,15 @@ macro_rules! dual_test {
             $(
                 #[cfg(feature = $solver_feature)]
                 furniture_problem_for_solver($solver);
+            )*
+        }
+
+        #[test]
+        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+        fn greater_than_or_equal_constraint() {
+            $(
+                #[cfg(feature = $solver_feature)]
+                greater_than_or_equal_constraint_for_solver($solver);
             )*
         }
     };


### PR DESCRIPTION
Fixes #82

## Summary

Corrects the sign of dual values returned for constraints written with `>=` while preserving the solver-specific objective-direction conventions already used by the dual integrations.

## Problem

`good_lp` normalizes every inequality sent to a solver as an upper-bound constraint. For a user constraint written as `a >= b`, the normalized expression is `b - a <= 0`, so the normalized right-hand side is the negation of the right-hand side written by the user. A dual returned for that normalized right-hand side therefore has the opposite sign from the corresponding user-facing shadow price.

The original constraint direction was discarded during normalization, and `ConstraintReference` retained only the row index. As a result, the HiGHS and Clarabel integrations returned the raw normalized value for the case reported in #82.

## Implementation

- Preserve the original constraint direction (`<=`, `==`, or `>=`) while retaining the existing normalized solver representation.
- Carry that direction through `ConstraintReference` without changing its existing index-based equality or debug representation.
- Map normalized dual values back to the user-facing convention in the dual-capable integrations. The reported maximization `>=` case is negated; existing `<=` and equality behavior is preserved.
- Keep Clarabel's objective direction in its solution so the correction is applied only on the maximization path, preserving its existing minimization behavior.
- Update all solver model implementations to construct direction-aware references. Solvers without dual-value support retain their existing runtime behavior.

## Regression coverage

Extends `tests/shadow_price.rs` with a solver-independent `>=` case:

```text
maximise  -2x
subject to x >= 1
```

The optimum is `x = 1`, and increasing the lower bound by one decreases the maximized objective by two, so the expected dual value is `-2`. A minimization counterpart also verifies that the Clarabel and HiGHS objective-direction handling remains consistent. Both cases run for HiGHS and Clarabel alongside the existing `<=` dual tests.

## Validation

- `cargo fmt -- --check`
- `git diff --check`
- `cargo clippy --all-targets --no-default-features --features "microlp,clarabel"`
- `cargo test --no-default-features --features clarabel --test shadow_price`
- WSL2 Ubuntu: `cargo test --no-default-features --features highs --test shadow_price`
- WSL2 Ubuntu: `cargo build --features all_default_solvers --tests`
- WSL2 Ubuntu: `cargo test --quiet --features all_default_solvers -- --test-threads=1`

The local CPLEX-specific check could not be run because this environment does not have a CPLEX installation. The repository's CPLEX CI job passed for the original revision; the follow-up revision is being rechecked by CI.