### PR TITLE
silence CBC solver output by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ minilp = [
 ] # minilp is not maintained anymore, we use the microlp fork instead
 
 [dependencies]
-coin_cbc = { version = "0.1", optional = true, default-features = false }
+coin_cbc = { git = "https://github.com/lovasoa/coin_cbc", rev = "1450d3b", optional = true, default-features = false }
 microlp = { version = "0.6.0", optional = true }
 lpsolve = { version = "1.0.1", optional = true }
 highs = { version = "2.2.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ minilp = [
 ] # minilp is not maintained anymore, we use the microlp fork instead
 
 [dependencies]
-coin_cbc = { git = "https://github.com/lovasoa/coin_cbc", rev = "1450d3b", optional = true, default-features = false }
+coin_cbc = { git = "https://github.com/lovasoa/coin_cbc", rev = "6c407e4", optional = true, default-features = false }
 microlp = { version = "0.6.0", optional = true }
 lpsolve = { version = "1.0.1", optional = true }
 highs = { version = "2.2.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ minilp = [
 ] # minilp is not maintained anymore, we use the microlp fork instead
 
 [dependencies]
-coin_cbc = { git = "https://github.com/lovasoa/coin_cbc", rev = "6c407e4", optional = true, default-features = false }
+coin_cbc = { git = "https://github.com/lovasoa/coin_cbc", rev = "8003dd3", optional = true, default-features = false }
 microlp = { version = "0.6.0", optional = true }
 lpsolve = { version = "1.0.1", optional = true }
 highs = { version = "2.2.0", optional = true }

--- a/src/solvers/coin_cbc.rs
+++ b/src/solvers/coin_cbc.rs
@@ -28,6 +28,7 @@ pub fn coin_cbc(to_solve: UnsolvedProblem) -> CoinCbcProblem {
         variables,
     } = to_solve;
     let mut model = Model::default();
+    model.set_log_level(0);
     let mut initial_solution = Vec::with_capacity(variables.initial_solution_len());
     let columns: Vec<Col> = variables
         .iter_variables_with_def()
@@ -110,6 +111,11 @@ impl CoinCbcProblem {
     /// ```
     pub fn set_parameter(&mut self, key: &str, value: &str) {
         self.model.set_parameter(key, value);
+    }
+
+    /// Set CBC's log level. A level of `0` suppresses normal solver output.
+    pub fn set_log_level(&mut self, log_level: i32) {
+        self.model.set_log_level(log_level);
     }
 }
 


### PR DESCRIPTION
Hi everyone :) sorry for the duplicate comment across prs and issues. Here is my suggested solution to the cbc verbosity issue in good_lp: expose Cbc_setLogLevel and set it to zero by default. I see the rust binding hasn't been updated in a long time and has old open issues. If the project is stale, just let us know and we'll switch to a different default solver in good_lp.

depends on https://github.com/KardinalAI/coin_cbc/pull/38 (todo: update cargo reference in this pr when that is merged)



fixes https://github.com/rust-or/good_lp/issues/117

## Summary

Make the good_lp CBC solver silent by default using CBC's native log-level API.

## Changes

- Depend on the coin_cbc branch exposing `Cbc_setLogLevel`.
- Set CBC's native log level to zero when constructing a good_lp CBC model.
- Expose `CoinCbcProblem::set_log_level` for callers that need to change it.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --lib --no-default-features --features coin_cbc -- --nocapture`
- The CBC-only test suite passes without solver progress output.
