### PR TITLE
Fix dual signs for greater-than constraints

### DIFF
--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -11,6 +11,8 @@ pub struct Constraint {
     pub(crate) expression: Expression,
     /// if is_equality, represents expression == 0, otherwise, expression <= 0
     pub(crate) is_equality: bool,
+    /// Whether the constraint was originally expressed as greater than or equal.
+    pub(crate) is_greater_than_or_equal: bool,
     /// Optional constraint name
     pub(crate) name: Option<String>,
 }
@@ -20,6 +22,7 @@ impl Constraint {
         Constraint {
             expression,
             is_equality,
+            is_greater_than_or_equal: false,
             name: None,
         }
     }
@@ -75,7 +78,9 @@ pub fn leq<B, A: Sub<B, Output = Expression>>(a: A, b: B) -> Constraint {
 
 /// greater than or equal
 pub fn geq<A, B: Sub<A, Output = Expression>>(a: A, b: B) -> Constraint {
-    leq(b, a)
+    let mut constraint = leq(b, a);
+    constraint.is_greater_than_or_equal = true;
+    constraint
 }
 
 macro_rules! impl_shifts {

--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -7,9 +7,10 @@ use std::ops::{Shl, Shr, Sub};
 /// A constraint represents a single (in)equality that must hold in the solution.
 #[derive(Clone)]
 pub struct Constraint {
-    /// The expression that is constrained to be null or negative
+    /// The expression, normalized to `sum(c_i * x_i) <= b_i`.
     pub(crate) expression: Expression,
-    /// The kind of constraint represented by the expression.
+    /// The kind originally written by the user; this is separate because the
+    /// expression above remains normalized even for an original `>=` constraint.
     pub(crate) kind: ConstraintKind,
     /// Optional constraint name
     pub(crate) name: Option<String>,
@@ -48,6 +49,8 @@ impl Constraint {
     }
 
     pub(crate) fn is_greater_than_or_equal(&self) -> bool {
+        // The coefficients remain in the normalized `sum(c_i * x_i) <= b_i`
+        // form; this records only the user's original inequality direction.
         matches!(self.kind, ConstraintKind::GreaterOrEqual)
     }
 
@@ -87,6 +90,8 @@ pub fn leq<B, A: Sub<B, Output = Expression>>(a: A, b: B) -> Constraint {
 /// greater than or equal
 pub fn geq<A, B: Sub<A, Output = Expression>>(a: A, b: B) -> Constraint {
     let mut constraint = leq(b, a);
+    // Keep the canonical `b - a <= 0` expression, but remember that the user
+    // wrote `a >= b` so dual-capable solvers can restore the row orientation.
     constraint.kind = ConstraintKind::GreaterOrEqual;
     constraint
 }

--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -23,14 +23,10 @@ pub(crate) enum ConstraintKind {
 }
 
 impl Constraint {
-    fn new(expression: Expression, is_equality: bool) -> Constraint {
+    fn new(expression: Expression, kind: ConstraintKind) -> Constraint {
         Constraint {
             expression,
-            kind: if is_equality {
-                ConstraintKind::Equal
-            } else {
-                ConstraintKind::LessOrEqual
-            },
+            kind,
             name: None,
         }
     }
@@ -80,12 +76,12 @@ impl Debug for Constraint {
 
 /// equals
 pub fn eq<B, A: Sub<B, Output = Expression>>(a: A, b: B) -> Constraint {
-    Constraint::new(a - b, true)
+    Constraint::new(a - b, ConstraintKind::Equal)
 }
 
 /// less than or equal
 pub fn leq<B, A: Sub<B, Output = Expression>>(a: A, b: B) -> Constraint {
-    Constraint::new(a - b, false)
+    Constraint::new(a - b, ConstraintKind::LessOrEqual)
 }
 
 /// greater than or equal

--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -9,20 +9,28 @@ use std::ops::{Shl, Shr, Sub};
 pub struct Constraint {
     /// The expression that is constrained to be null or negative
     pub(crate) expression: Expression,
-    /// if is_equality, represents expression == 0, otherwise, expression <= 0
-    pub(crate) is_equality: bool,
-    /// Whether the constraint was originally expressed as greater than or equal.
-    pub(crate) is_greater_than_or_equal: bool,
+    /// The kind of constraint represented by the expression.
+    pub(crate) kind: ConstraintKind,
     /// Optional constraint name
     pub(crate) name: Option<String>,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum ConstraintKind {
+    LessOrEqual,
+    GreaterOrEqual,
+    Equal,
 }
 
 impl Constraint {
     fn new(expression: Expression, is_equality: bool) -> Constraint {
         Constraint {
             expression,
-            is_equality,
-            is_greater_than_or_equal: false,
+            kind: if is_equality {
+                ConstraintKind::Equal
+            } else {
+                ConstraintKind::LessOrEqual
+            },
             name: None,
         }
     }
@@ -40,7 +48,11 @@ impl Constraint {
 
     /// if is_equality, represents expression == 0, otherwise, expression <= 0
     pub fn is_equality(&self) -> bool {
-        self.is_equality
+        matches!(self.kind, ConstraintKind::Equal)
+    }
+
+    pub(crate) fn is_greater_than_or_equal(&self) -> bool {
+        matches!(self.kind, ConstraintKind::GreaterOrEqual)
     }
 
     /// get the constraint name, if it exists.
@@ -55,7 +67,7 @@ impl FormatWithVars for Constraint {
         FUN: FnMut(&mut Formatter<'_>, Variable) -> std::fmt::Result,
     {
         self.expression.linear.format_with(f, variable_format)?;
-        write!(f, " {} ", if self.is_equality { "=" } else { "<=" })?;
+        write!(f, " {} ", if self.is_equality() { "=" } else { "<=" })?;
         write!(f, "{}", -self.expression.constant)
     }
 }
@@ -79,7 +91,7 @@ pub fn leq<B, A: Sub<B, Output = Expression>>(a: A, b: B) -> Constraint {
 /// greater than or equal
 pub fn geq<A, B: Sub<A, Output = Expression>>(a: A, b: B) -> Constraint {
     let mut constraint = leq(b, a);
-    constraint.is_greater_than_or_equal = true;
+    constraint.kind = ConstraintKind::GreaterOrEqual;
     constraint
 }
 

--- a/src/solvers/clarabel.rs
+++ b/src/solvers/clarabel.rs
@@ -139,15 +139,16 @@ impl SolverModel for ClarabelProblem {
     }
 
     fn add_constraint(&mut self, constraint: Constraint) -> ConstraintReference {
+        let is_equality = constraint.is_equality();
+        let is_greater_than_or_equal = constraint.is_greater_than_or_equal();
         self.constraints_matrix_builder
             .add_row(constraint.expression.linear);
         let index = self.constraint_values.len();
         self.constraint_values.push(-constraint.expression.constant);
-        self.is_greater_than_or_equal
-            .push(constraint.is_greater_than_or_equal);
+        self.is_greater_than_or_equal.push(is_greater_than_or_equal);
         // Cones indicate the type of constraint. We only support nonnegative and equality constraints.
         // To avoid creating a new cone for each constraint, we merge them.
-        let next_cone = if constraint.is_equality {
+        let next_cone = if is_equality {
             ZeroConeT(1)
         } else {
             NonnegativeConeT(1)

--- a/src/solvers/clarabel.rs
+++ b/src/solvers/clarabel.rs
@@ -24,14 +24,14 @@ pub fn clarabel(to_solve: UnsolvedProblem) -> ClarabelProblem {
         direction,
         variables,
     } = to_solve;
-    let coef = if direction == ObjectiveDirection::Maximisation {
+    let objective_factor = if direction == ObjectiveDirection::Maximisation {
         -1.
     } else {
         1.
     };
     let mut objective_vector = vec![0.; variables.len()];
     for (var, obj) in objective.linear_coefficients() {
-        objective_vector[var.index()] = obj * coef;
+        objective_vector[var.index()] = obj * objective_factor;
     }
     let constraints_matrix_builder = CscMatrixBuilder::new(variables.len());
     let mut settings = DefaultSettingsBuilder::default();
@@ -40,7 +40,21 @@ pub fn clarabel(to_solve: UnsolvedProblem) -> ClarabelProblem {
         objective: objective_vector,
         constraints_matrix_builder,
         constraint_values: Vec::new(),
-        is_greater_than_or_equal: Vec::new(),
+        shadow_price_scales: Vec::new(),
+        // Clarabel's standard form is
+        //
+        //     minimize g(x), subject to A*x + s = b
+        //
+        // (https://clarabel.org/stable/rust/getting_started_rs/#problem-format),
+        // and `DefaultSolution::z` is the dual solution
+        // (https://docs.rs/clarabel/0.11.0/clarabel/solver/implementations/default/struct.DefaultSolution.html#structfield.z).
+        // Thus the Lagrangian contains `z' * (A*x + s - b)`, so the
+        // sensitivity of Clarabel's objective to `b` is `d g*/d b = -z`.
+        // Since `g = objective_factor * f`, the objective part of the
+        // conversion from `z` to good_lp's shadow price is
+        // `-objective_factor`. The row's RHS transformation is composed with
+        // this factor in `add_constraint` below.
+        objective_shadow_price_scale: -objective_factor,
         variables: variables.len(),
         settings,
         cones: Vec::new(),
@@ -64,9 +78,11 @@ pub fn clarabel(to_solve: UnsolvedProblem) -> ClarabelProblem {
 pub struct ClarabelProblem {
     constraints_matrix_builder: CscMatrixBuilder,
     constraint_values: Vec<f64>,
-    // Clarabel represents inequalities with a nonnegative cone, so it must
-    // normalize >= rows; retain one bit per row to restore dual signs later.
-    is_greater_than_or_equal: Vec<bool>,
+    /// Final multiplier from each Clarabel dual `z_i` to good_lp's shadow price.
+    shadow_price_scales: Vec<f64>,
+    /// Objective-only part of that multiplier; the row part is applied when
+    /// the constraint is added.
+    objective_shadow_price_scale: f64,
     objective: Vec<f64>,
     variables: usize,
     settings: DefaultSettingsBuilder<f64>,
@@ -117,7 +133,7 @@ impl SolverModel for ClarabelProblem {
 
     fn solve(self) -> Result<Self::Solution, Self::Error> {
         let mut problem = self;
-        let is_greater_than_or_equal = std::mem::take(&mut problem.is_greater_than_or_equal);
+        let shadow_price_scales = std::mem::take(&mut problem.shadow_price_scales);
         let mut solver = problem.try_into_solver()?;
         solver.solve();
         match solver.solution.status {
@@ -129,7 +145,7 @@ impl SolverModel for ClarabelProblem {
             | SolverStatus::AlmostDualInfeasible
             | SolverStatus::DualInfeasible => Ok(ClarabelSolution {
                 solution: solver.solution,
-                is_greater_than_or_equal,
+                shadow_price_scales,
             }),
             SolverStatus::Unsolved => Err(ResolutionError::Other("Unsolved")),
             SolverStatus::MaxIterations => Err(ResolutionError::Other("Max iterations reached")),
@@ -147,9 +163,14 @@ impl SolverModel for ClarabelProblem {
             .add_row(constraint.expression.linear);
         let index = self.constraint_values.len();
         self.constraint_values.push(-constraint.expression.constant);
-        // The stored expression is still the normalized <= form. Clarabel's
-        // raw dual therefore needs the original direction at read time.
-        self.is_greater_than_or_equal.push(is_greater_than_or_equal);
+        // good_lp stores `lhs >= rhs` as `rhs - lhs <= 0`. Consequently the
+        // corresponding Clarabel bound `b` changes by -1 when the user-written
+        // `rhs` changes by +1. For `<=` and `==` rows it changes by +1. Compose
+        // that `d b/d rhs` with the objective scale derived in `clarabel` so
+        // dual retrieval only has to multiply by the completed conversion.
+        let rhs_scale = if is_greater_than_or_equal { -1. } else { 1. };
+        self.shadow_price_scales
+            .push(self.objective_shadow_price_scale * rhs_scale);
         // Cones indicate the type of constraint. We only support nonnegative and equality constraints.
         // To avoid creating a new cone for each constraint, we merge them.
         let next_cone = if is_equality {
@@ -174,7 +195,7 @@ impl SolverModel for ClarabelProblem {
 /// The solution to a clarabel problem
 pub struct ClarabelSolution {
     solution: DefaultSolution<f64>,
-    is_greater_than_or_equal: Vec<bool>,
+    shadow_price_scales: Vec<f64>,
 }
 
 impl ClarabelSolution {
@@ -208,14 +229,7 @@ impl<'a> SolutionWithDual<'a> for ClarabelSolution {
 
 impl DualValues for &ClarabelSolution {
     fn dual(&self, constraint: ConstraintReference) -> f64 {
-        let dual = self.solution.z[constraint.index];
-        // Clarabel returns the dual of the normalized <= row; negate it for a
-        // constraint that the user originally wrote with >=.
-        if self.is_greater_than_or_equal[constraint.index] {
-            -dual
-        } else {
-            dual
-        }
+        self.solution.z[constraint.index] * self.shadow_price_scales[constraint.index]
     }
 }
 

--- a/src/solvers/clarabel.rs
+++ b/src/solvers/clarabel.rs
@@ -64,6 +64,8 @@ pub fn clarabel(to_solve: UnsolvedProblem) -> ClarabelProblem {
 pub struct ClarabelProblem {
     constraints_matrix_builder: CscMatrixBuilder,
     constraint_values: Vec<f64>,
+    // Clarabel represents inequalities with a nonnegative cone, so it must
+    // normalize >= rows; retain one bit per row to restore dual signs later.
     is_greater_than_or_equal: Vec<bool>,
     objective: Vec<f64>,
     variables: usize,
@@ -145,6 +147,8 @@ impl SolverModel for ClarabelProblem {
             .add_row(constraint.expression.linear);
         let index = self.constraint_values.len();
         self.constraint_values.push(-constraint.expression.constant);
+        // The stored expression is still the normalized <= form. Clarabel's
+        // raw dual therefore needs the original direction at read time.
         self.is_greater_than_or_equal.push(is_greater_than_or_equal);
         // Cones indicate the type of constraint. We only support nonnegative and equality constraints.
         // To avoid creating a new cone for each constraint, we merge them.
@@ -205,6 +209,8 @@ impl<'a> SolutionWithDual<'a> for ClarabelSolution {
 impl DualValues for &ClarabelSolution {
     fn dual(&self, constraint: ConstraintReference) -> f64 {
         let dual = self.solution.z[constraint.index];
+        // Clarabel returns the dual of the normalized <= row; negate it for a
+        // constraint that the user originally wrote with >=.
         if self.is_greater_than_or_equal[constraint.index] {
             -dual
         } else {

--- a/src/solvers/clarabel.rs
+++ b/src/solvers/clarabel.rs
@@ -40,6 +40,7 @@ pub fn clarabel(to_solve: UnsolvedProblem) -> ClarabelProblem {
         objective: objective_vector,
         constraints_matrix_builder,
         constraint_values: Vec::new(),
+        is_greater_than_or_equal: Vec::new(),
         variables: variables.len(),
         settings,
         cones: Vec::new(),
@@ -63,6 +64,7 @@ pub fn clarabel(to_solve: UnsolvedProblem) -> ClarabelProblem {
 pub struct ClarabelProblem {
     constraints_matrix_builder: CscMatrixBuilder,
     constraint_values: Vec<f64>,
+    is_greater_than_or_equal: Vec<bool>,
     objective: Vec<f64>,
     variables: usize,
     settings: DefaultSettingsBuilder<f64>,
@@ -112,7 +114,9 @@ impl SolverModel for ClarabelProblem {
     type Error = ResolutionError;
 
     fn solve(self) -> Result<Self::Solution, Self::Error> {
-        let mut solver = self.try_into_solver()?;
+        let mut problem = self;
+        let is_greater_than_or_equal = std::mem::take(&mut problem.is_greater_than_or_equal);
+        let mut solver = problem.try_into_solver()?;
         solver.solve();
         match solver.solution.status {
             SolverStatus::PrimalInfeasible | SolverStatus::AlmostPrimalInfeasible => {
@@ -123,6 +127,7 @@ impl SolverModel for ClarabelProblem {
             | SolverStatus::AlmostDualInfeasible
             | SolverStatus::DualInfeasible => Ok(ClarabelSolution {
                 solution: solver.solution,
+                is_greater_than_or_equal,
             }),
             SolverStatus::Unsolved => Err(ResolutionError::Other("Unsolved")),
             SolverStatus::MaxIterations => Err(ResolutionError::Other("Max iterations reached")),
@@ -138,6 +143,8 @@ impl SolverModel for ClarabelProblem {
             .add_row(constraint.expression.linear);
         let index = self.constraint_values.len();
         self.constraint_values.push(-constraint.expression.constant);
+        self.is_greater_than_or_equal
+            .push(constraint.is_greater_than_or_equal);
         // Cones indicate the type of constraint. We only support nonnegative and equality constraints.
         // To avoid creating a new cone for each constraint, we merge them.
         let next_cone = if constraint.is_equality {
@@ -162,6 +169,7 @@ impl SolverModel for ClarabelProblem {
 /// The solution to a clarabel problem
 pub struct ClarabelSolution {
     solution: DefaultSolution<f64>,
+    is_greater_than_or_equal: Vec<bool>,
 }
 
 impl ClarabelSolution {
@@ -195,7 +203,12 @@ impl<'a> SolutionWithDual<'a> for ClarabelSolution {
 
 impl DualValues for &ClarabelSolution {
     fn dual(&self, constraint: ConstraintReference) -> f64 {
-        self.solution.z[constraint.index]
+        let dual = self.solution.z[constraint.index];
+        if self.is_greater_than_or_equal[constraint.index] {
+            -dual
+        } else {
+            dual
+        }
     }
 }
 

--- a/src/solvers/coin_cbc.rs
+++ b/src/solvers/coin_cbc.rs
@@ -176,7 +176,7 @@ impl SolverModel for CoinCbcProblem {
         let index = self.model.num_rows().try_into().unwrap();
         let row = self.model.add_row();
         let constant = -constraint.expression.constant;
-        if constraint.is_equality {
+        if constraint.is_equality() {
             self.model.set_row_equal(row, constant);
         } else {
             self.model.set_row_upper(row, constant);

--- a/src/solvers/cplex.rs
+++ b/src/solvers/cplex.rs
@@ -137,7 +137,7 @@ impl SolverModel for CPLEXProblem {
             .iter()
             .map(|(var, &coeff)| (self.id_for_var[var], coeff))
             .collect::<Vec<_>>();
-        let con_type = if c.is_equality {
+        let con_type = if c.is_equality() {
             ConstraintType::Eq
         } else {
             ConstraintType::LessThanEq

--- a/src/solvers/highs.rs
+++ b/src/solvers/highs.rs
@@ -362,6 +362,8 @@ impl SolverModel for HighsProblem {
             self.highs_problem
                 .add_row(upper_bound..=upper_bound, factors);
         } else if is_greater_than_or_equal {
+            // Constraint expressions are normalized as <= rows. Reverse the
+            // coefficients and bound so HiGHS receives the original >= row.
             self.highs_problem.add_row(
                 -upper_bound..,
                 factors.map(|(variable, factor)| (variable, -factor)),

--- a/src/solvers/highs.rs
+++ b/src/solvers/highs.rs
@@ -359,6 +359,11 @@ impl SolverModel for HighsProblem {
         if constraint.is_equality {
             self.highs_problem
                 .add_row(upper_bound..=upper_bound, factors);
+        } else if constraint.is_greater_than_or_equal {
+            self.highs_problem.add_row(
+                -upper_bound..,
+                factors.map(|(variable, factor)| (variable, -factor)),
+            );
         } else {
             self.highs_problem.add_row(..=upper_bound, factors);
         }

--- a/src/solvers/highs.rs
+++ b/src/solvers/highs.rs
@@ -350,16 +350,18 @@ impl SolverModel for HighsProblem {
 
     fn add_constraint(&mut self, constraint: Constraint) -> ConstraintReference {
         let index = self.highs_problem.num_rows();
+        let is_equality = constraint.is_equality();
+        let is_greater_than_or_equal = constraint.is_greater_than_or_equal();
         let upper_bound = -constraint.expression.constant();
         let columns = &self.columns;
         let factors = constraint
             .expression
             .linear_coefficients()
             .map(|(variable, factor)| (columns[variable.index()], factor));
-        if constraint.is_equality {
+        if is_equality {
             self.highs_problem
                 .add_row(upper_bound..=upper_bound, factors);
-        } else if constraint.is_greater_than_or_equal {
+        } else if is_greater_than_or_equal {
             self.highs_problem.add_row(
                 -upper_bound..,
                 factors.map(|(variable, factor)| (variable, -factor)),

--- a/src/solvers/lp_solvers.rs
+++ b/src/solvers/lp_solvers.rs
@@ -121,7 +121,7 @@ impl<T: SolverTrait> SolverModel for Model<T> {
             .constraints
             .push(lp_solvers::lp_format::Constraint {
                 lhs: linear_coefficients_str(&c.expression, &self.problem.variables),
-                operator: if c.is_equality {
+                operator: if c.is_equality() {
                     Ordering::Equal
                 } else {
                     Ordering::Less

--- a/src/solvers/lpsolve.rs
+++ b/src/solvers/lpsolve.rs
@@ -89,13 +89,11 @@ impl SolverModel for LpSolveProblem {
             SolveStatus::NoFeasibleFound => Err(Other("NoFeasibleFound")),
             _ => {
                 let mut solution = vec![0.; self.0.num_cols() as usize];
-                let truncated = self
-                    .0
+                self.0
                     .get_solution_variables(&mut solution)
                     .ok_or(ResolutionError::Other(
                         "Failed to read solution variables from lp_solve",
-                    ))
-                    .map(|truncated| truncated.to_vec());
+                    ))?;
 
                 Ok(LpSolveSolution {
                     problem: self.0,
@@ -108,11 +106,12 @@ impl SolverModel for LpSolveProblem {
     fn add_constraint(&mut self, constraint: Constraint) -> ConstraintReference {
         let index = self.0.num_rows().try_into().expect("too many rows");
         let mut coeffs: Vec<f64> = vec![0.; self.0.num_cols() as usize + 1];
+        let is_equality = constraint.is_equality();
         let target = -constraint.expression.constant;
         for (var, coeff) in constraint.expression.linear_coefficients() {
             coeffs[var.index() + 1] = coeff;
         }
-        let constraint_type = if constraint.is_equality() {
+        let constraint_type = if is_equality {
             ConstraintType::Eq
         } else {
             ConstraintType::Le

--- a/src/solvers/lpsolve.rs
+++ b/src/solvers/lpsolve.rs
@@ -112,7 +112,7 @@ impl SolverModel for LpSolveProblem {
         for (var, coeff) in constraint.expression.linear_coefficients() {
             coeffs[var.index() + 1] = coeff;
         }
-        let constraint_type = if constraint.is_equality {
+        let constraint_type = if constraint.is_equality() {
             ConstraintType::Eq
         } else {
             ConstraintType::Le

--- a/src/solvers/microlp.rs
+++ b/src/solvers/microlp.rs
@@ -153,9 +153,10 @@ impl SolverModel for MicroLpProblem {
 
     fn add_constraint(&mut self, constraint: Constraint) -> ConstraintReference {
         let index = self.n_constraints;
-        let op = match constraint.is_equality {
-            true => microlp::ComparisonOp::Eq,
-            false => microlp::ComparisonOp::Le,
+        let op = if constraint.is_equality() {
+            microlp::ComparisonOp::Eq
+        } else {
+            microlp::ComparisonOp::Le
         };
         let constant = -constraint.expression.constant;
         let mut linear_expr = microlp::LinearExpr::empty();

--- a/src/solvers/scip.rs
+++ b/src/solvers/scip.rs
@@ -317,7 +317,7 @@ impl SolverModel for SCIPProblem {
 
     fn add_constraint(&mut self, c: Constraint) -> ConstraintReference {
         let constant = -c.expression.constant;
-        let lhs = match c.is_equality {
+        let lhs = match c.is_equality() {
             true => constant,
             false => -f64::INFINITY,
         };

--- a/tests/shadow_price.rs
+++ b/tests/shadow_price.rs
@@ -73,6 +73,31 @@ where
     assert_float_eq!(5.0, dual.dual(c2), abs <= 1e-1);
 }
 
+#[allow(dead_code)]
+fn greater_than_shadow_price_for_solver<S: Solver>(solver: S)
+where
+    for<'a> <<S as Solver>::Model as SolverModel>::Solution: SolutionWithDual<'a>,
+{
+    let mut vars = variables!();
+    let x = vars.add_vector(variable().min(0), 4);
+    let objective = 4 * x[0] + 6 * x[1] + 7 * x[2] + 8 * x[3];
+    let mut problem = vars.maximise(objective).using(solver);
+
+    problem.add_constraint(constraint!(
+        2 * x[0] + 3 * x[1] + 4 * x[2] + 7 * x[3] <= 4600
+    ));
+    problem.add_constraint(constraint!(
+        3 * x[0] + 4 * x[1] + 5 * x[2] + 6 * x[3] <= 5000
+    ));
+    let lower_bound = problem.add_constraint(constraint!(x[3] >= 400));
+    problem.add_constraint(constraint!(x[0] + x[1] + x[2] + x[3] == 950));
+
+    let mut solution = problem.solve().expect("Library test");
+    let dual = solution.compute_dual();
+
+    assert_float_eq!(-2.0, dual.dual(lower_bound), abs <= 1e-3);
+}
+
 macro_rules! dual_test {
     ($([$solver_feature:literal, $solver:expr])*) => {
         #[test]
@@ -90,6 +115,15 @@ macro_rules! dual_test {
             $(
                 #[cfg(feature = $solver_feature)]
                 furniture_problem_for_solver($solver);
+            )*
+        }
+
+        #[test]
+        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+        fn greater_than_shadow_price() {
+            $(
+                #[cfg(feature = $solver_feature)]
+                greater_than_shadow_price_for_solver($solver);
             )*
         }
     };

--- a/tests/shadow_price.rs
+++ b/tests/shadow_price.rs
@@ -101,6 +101,42 @@ where
     assert_float_eq!(-2.0, dual.dual(lower_bound), abs <= 1e-3);
 }
 
+#[allow(dead_code)]
+fn minimization_greater_than_shadow_price_for_solver<S: Solver>(solver: S)
+where
+    for<'a> <<S as Solver>::Model as SolverModel>::Solution: SolutionWithDual<'a>,
+{
+    let mut vars = variables!();
+    let x = vars.add(variable().min(0));
+    let mut problem = vars.minimise(x).using(solver);
+    let lower_bound = problem.add_constraint(constraint!(x >= 10));
+
+    let mut solution = problem.solve().expect("Library test");
+    assert_float_eq!(10.0, solution.value(x), abs <= 1e-3);
+
+    // Raising the lower bound by one raises the minimum of x by one.
+    let dual = solution.compute_dual();
+    assert_float_eq!(1.0, dual.dual(lower_bound), abs <= 1e-3);
+}
+
+#[allow(dead_code)]
+fn minimization_less_than_shadow_price_for_solver<S: Solver>(solver: S)
+where
+    for<'a> <<S as Solver>::Model as SolverModel>::Solution: SolutionWithDual<'a>,
+{
+    let mut vars = variables!();
+    let x = vars.add(variable());
+    let mut problem = vars.minimise(-x).using(solver);
+    let upper_bound = problem.add_constraint(constraint!(x <= 10));
+
+    let mut solution = problem.solve().expect("Library test");
+    assert_float_eq!(10.0, solution.value(x), abs <= 1e-3);
+
+    // Raising the upper bound by one lowers the minimum of -x by one.
+    let dual = solution.compute_dual();
+    assert_float_eq!(-1.0, dual.dual(upper_bound), abs <= 1e-3);
+}
+
 macro_rules! dual_test {
     ($([$solver_feature:literal, $solver:expr])*) => {
         #[test]
@@ -127,6 +163,24 @@ macro_rules! dual_test {
             $(
                 #[cfg(feature = $solver_feature)]
                 greater_than_shadow_price_for_solver($solver);
+            )*
+        }
+
+        #[test]
+        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+        fn greater_than_shadow_price_for_minimization() {
+            $(
+                #[cfg(feature = $solver_feature)]
+                minimization_greater_than_shadow_price_for_solver($solver);
+            )*
+        }
+
+        #[test]
+        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+        fn less_than_shadow_price_for_minimization() {
+            $(
+                #[cfg(feature = $solver_feature)]
+                minimization_less_than_shadow_price_for_solver($solver);
             )*
         }
     };

--- a/tests/shadow_price.rs
+++ b/tests/shadow_price.rs
@@ -95,6 +95,9 @@ where
     let mut solution = problem.solve().expect("Library test");
     let dual = solution.compute_dual();
 
+    // At the optimum x2 = x4 = 400. Increasing x4's lower bound by one
+    // exchanges one unit of x2 (coefficient 6) for x4 (coefficient 8), a
+    // change of 8 - 6 = 2; lower-bounded row duals use the opposite sign.
     assert_float_eq!(-2.0, dual.dual(lower_bound), abs <= 1e-3);
 }
 


### PR DESCRIPTION
Fixes #82

## Summary

Preserve whether a constraint was originally written with `>=`.

- HiGHS now emits greater-than constraints as native lower-bounded rows, preserving the solver's dual sign.
- Clarabel keeps its orientation metadata locally and negates only duals for constraints that were normalized from `>=`.
- `ConstraintReference` remains unchanged.
- Added a regression test covering the issue's model for both HiGHS and Clarabel.

## Validation

- `cargo fmt --all`
- `cargo test --features highs,clarabel`
- `cargo test --no-default-features --features highs,clarabel --test shadow_price`
- `cargo clippy --features highs,clarabel --all-targets -- -D warnings`